### PR TITLE
feat: switch defaults to use manifest from GH pages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ struct GlobalArgs {
         hide(true),
         value_name = "FILE",
         env = "MIDENUP_MANIFEST_URI",
-        default_value = "file://manifest/channel-manifest.json"
+        default_value = manifest::Manifest::PUBLISHED_MANIFEST_URI
     )]
     manifest_uri: String,
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -30,6 +30,9 @@ impl Default for Manifest {
 }
 
 impl Manifest {
+    pub const PUBLISHED_MANIFEST_URI: &str =
+        "https://0xmiden.github.io/midenup/channel-manifest.json";
+
     /// Loads a [Manifest] from the given URI
     pub fn load_from(uri: impl AsRef<str>) -> anyhow::Result<Self> {
         let uri = uri.as_ref();
@@ -77,6 +80,15 @@ mod tests {
     #[test]
     fn validate_current_channel_manifest() {
         let manifest = Manifest::load_from("file://manifest/channel-manifest.json").unwrap();
+
+        let stable = manifest.get_channel(&ChannelType::Stable).unwrap();
+
+        assert!(stable.get_component("std").is_some());
+    }
+
+    #[test]
+    fn validate_published_channel_manifest() {
+        let manifest = Manifest::load_from(Manifest::PUBLISHED_MANIFEST_URI).unwrap();
 
         let stable = manifest.get_channel(&ChannelType::Stable).unwrap();
 


### PR DESCRIPTION
This replaces the default channel manifest URI with the manifest published to GitHub Pages. Note that you can still experiment with the local manifest by setting `MIDENUP_MANIFEST_URI=file://path/to/channel-manifest.json`, where the path is either relative to the current working directory, or absolute.