### PR TITLE
feat: add `rustup_channel` to `channel_manifest.json`

### DIFF
--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -23,11 +23,13 @@
         },
         {
           "name": "midenc",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "rustup_channel": "nightly-2025-03-20"
         },
         {
           "name": "cargo-miden",
-          "version": "0.1.0"
+          "version": "0.1.0",
+          "rustup_channel": "nightly-2025-03-20"
         }
       ]
     }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -37,6 +37,9 @@ pub struct Component {
     /// Other components that are required if this component is installed
     #[serde(default)]
     pub requires: Vec<String>,
+    /// If not None, then this component requires a specific toolchain to compile.
+    #[serde(default)]
+    pub rustup_channel: Option<String>,
 }
 
 impl Component {
@@ -46,6 +49,7 @@ impl Component {
             version,
             features: vec![],
             requires: vec![],
+            rustup_channel: None,
         }
     }
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -97,6 +97,9 @@ fn main() {
     {% for component in installable_components %}
     // Install {{ component.name }}
     let mut child = Command::new("cargo")
+        .arg(
+          "{{ component.required_toolchain }}",
+        )
         .arg("install")
         .args([
         {%- for arg in component.args %}
@@ -189,6 +192,9 @@ fn main() {
                 },
             }
 
+            let required_toolchain =
+                component.rustup_channel.clone().unwrap_or(String::from("+stable"));
+
             // Enable optional features, if present
             if !component.features.is_empty() {
                 let features = component.features.join(",");
@@ -198,6 +204,7 @@ fn main() {
 
             upon::value! {
                 name: component.name.to_string(),
+                required_toolchain: required_toolchain,
                 args: args,
             }
         })

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,11 +1,11 @@
 use std::io::Write;
 
-use anyhow::{Context, bail};
+use anyhow::{bail, Context};
 
 use crate::{
-    Config,
     channel::{Channel, ChannelType},
     version::Authority,
+    Config,
 };
 
 /// Installs a specified toolchain by channel or version.

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,11 +1,11 @@
 use std::io::Write;
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 
 use crate::{
+    Config,
     channel::{Channel, ChannelType},
     version::Authority,
-    Config,
 };
 
 /// Installs a specified toolchain by channel or version.


### PR DESCRIPTION
Closes: #10 

Add an additional `rustup_channel` field to components if they need a specific rust toolchain. Add this field to `midenc` and `cargo-miden` which need the `nightly-2025-03-20` toolchain 