### PR TITLE
feat: create local manifest after installing

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -8,7 +8,7 @@ use crate::version::Authority;
 ///
 /// Different channels have different stability guarantees. See the specific details for the
 /// channel you are interested in to learn more.
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Channel {
     pub name: semver::Version,
 
@@ -42,8 +42,8 @@ impl Channel {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
+#[derive(Serialize, Debug, PartialEq, Eq, Clone)]
 pub enum ChannelAlias {
     /// Represents `stable`
     Stable,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -42,8 +42,8 @@ impl Channel {
     }
 }
 
-#[serde(rename_all = "snake_case")]
 #[derive(Serialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum ChannelAlias {
     /// Represents `stable`
     Stable,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -12,6 +12,7 @@ use crate::version::Authority;
 pub struct Channel {
     pub name: semver::Version,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub alias: Option<ChannelAlias>,
 
     /// The set of toolchain components available in this channel
@@ -42,7 +43,7 @@ impl Channel {
 }
 
 #[derive(Serialize, Debug, PartialEq, Eq)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum ChannelAlias {
     /// Represents `stable`
     Stable,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -95,12 +95,15 @@ pub struct Component {
     pub version: Authority,
     /// Optional features to enable, if applicable, when installing this component
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub features: Vec<String>,
     /// Other components that are required if this component is installed
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub requires: Vec<String>,
     /// If not None, then this component requires a specific toolchain to compile.
     #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rustup_channel: Option<String>,
 }
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -42,6 +42,30 @@ impl Channel {
     }
 }
 
+impl PartialEq for Channel {
+    fn eq(&self, other: &Self) -> bool {
+        // NOTE: To channels are equal regardless of their aliases
+        let equal_name = self.name == other.name;
+        if !equal_name {
+            return false;
+        }
+
+        let my_components: std::collections::HashSet<Component> =
+            self.components.clone().into_iter().collect();
+
+        let other_components: std::collections::HashSet<Component> =
+            self.components.clone().into_iter().collect();
+
+        let equal_components = other_components == my_components;
+
+        if !equal_components {
+            return false;
+        }
+
+        true
+    }
+}
+
 #[derive(Serialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum ChannelAlias {
@@ -87,7 +111,7 @@ impl core::str::FromStr for ChannelAlias {
 }
 
 /// An installable component of a toolchain
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
 pub struct Component {
     /// The canonical name of this toolchain component
     pub name: Cow<'static, str>,

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -35,12 +35,14 @@ pub fn init(config: &Config) -> anyhow::Result<()> {
     // The local manifest contains the installed toolchains with the
     // corresponding components
     let local_manifest_file = config.midenup_home.join("manifest").with_extension("json");
-    std::fs::File::create(&local_manifest_file).with_context(|| {
-        format!(
-            "failed to create local manifest.json file in: '{}'",
-            local_manifest_file.display()
-        )
-    })?;
+    if !local_manifest_file.exists() {
+        std::fs::File::create(&local_manifest_file).with_context(|| {
+            format!(
+                "failed to create local manifest.json file in: '{}'",
+                local_manifest_file.display()
+            )
+        })?;
+    }
 
     let bin_dir = config.midenup_home.join("bin");
     if !bin_dir.exists() {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -32,18 +32,6 @@ pub fn init(config: &Config) -> anyhow::Result<()> {
         })?;
     }
 
-    // The local manifest contains the installed toolchains with the
-    // corresponding components
-    let local_manifest_file = config.midenup_home.join("manifest").with_extension("json");
-    if !local_manifest_file.exists() {
-        std::fs::File::create(&local_manifest_file).with_context(|| {
-            format!(
-                "failed to create local manifest.json file in: '{}'",
-                local_manifest_file.display()
-            )
-        })?;
-    }
-
     let bin_dir = config.midenup_home.join("bin");
     if !bin_dir.exists() {
         std::fs::create_dir_all(&bin_dir).with_context(|| {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -51,6 +51,7 @@ pub fn install(config: &Config, channel: &Channel) -> anyhow::Result<()> {
     child.wait().context("failed to execute toolchain installer")?;
 
     let is_latest_stable = config.manifest.is_latest_stable(channel);
+
     // If stable is installed, update the symlink
     if is_latest_stable {
         // NOTE: This is an absolute file path, maybe a relative symlink would be more
@@ -62,6 +63,7 @@ pub fn install(config: &Config, channel: &Channel) -> anyhow::Result<()> {
         utils::symlink(&stable_dir, &toolchain_dir).expect("Couldn't create stable dir");
     }
 
+    // Update local manifest
     let local_manifest_path = config.midenup_home.join("manifest").with_extension("json");
     let local_manifest_uri = format!(
         "file://{}",

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -86,7 +86,11 @@ pub fn install(config: &Config, channel: &Channel) -> anyhow::Result<()> {
             )
         })?;
     local_manifest_file
-        .write_all(serde_json::to_string_pretty(&local_manifest).unwrap().as_bytes())
+        .write_all(
+            serde_json::to_string_pretty(&local_manifest)
+                .context("Couldn't serialize local manifest")?
+                .as_bytes(),
+        )
         .unwrap();
 
     Ok(())

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -55,6 +55,25 @@ pub fn install(config: &Config, channel: &Channel) -> anyhow::Result<()> {
         utils::symlink(&stable_dir, &toolchain_dir).expect("Couldn't create stable dir");
     }
 
+    let local_manifest_path = config.midenup_home.join("manifest").with_extension("json");
+    let local_manifest_uri = format!(
+        "file://{}",
+        local_manifest_path.to_str().context("Couldn't convert miden directory")?,
+    );
+
+    let local_manifest = Manifest::load_from(local_manifest_uri).unwrap_or_default();
+
+    let mut local_manifest_file =
+        std::fs::File::create(&local_manifest_path).with_context(|| {
+            format!(
+                "failed to create file for install script at '{}'",
+                local_manifest_path.display()
+            )
+        })?;
+    local_manifest_file
+        .write_all(serde_json::to_string_pretty(&local_manifest).unwrap().as_bytes())
+        .unwrap();
+
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,7 +127,6 @@ fn main() -> anyhow::Result<()> {
                 .ok_or_else(|| {
                     anyhow!("MIDENUP_HOME is unset, and the default location is unavailable")
                 })?;
-            std::dbg!("Parsed");
 
             Config::init(midenup_home, &config.manifest_uri)?
         },

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -74,7 +74,7 @@ impl Manifest {
     pub fn is_latest_stable(&self, channel: &Channel) -> bool {
         self.channels.iter().filter(|c| c.is_stable()).all(|c| {
             let comparison = channel.name.cmp_precedence(&c.name);
-            matches!(comparison, std::cmp::Ordering::Less | std::cmp::Ordering::Equal)
+            matches!(comparison, std::cmp::Ordering::Greater | std::cmp::Ordering::Equal)
         })
     }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -68,6 +68,9 @@ impl Manifest {
         Ok(manifest)
     }
 
+    pub fn add_channel(&mut self, channel: Channel) {
+        self.channels.push(channel);
+    }
     pub fn is_latest_stable(&self, channel: &Channel) -> bool {
         self.channels.iter().filter(|c| c.is_stable()).all(|c| {
             let comparison = channel.name.cmp_precedence(&c.name);

--- a/src/version.rs
+++ b/src/version.rs
@@ -3,7 +3,7 @@ use std::{fmt, path::PathBuf};
 use serde::{Deserialize, Serialize};
 
 /// Represents the canonical versioning authority for a tool or toolchain
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Authority {
     /// The authority for this tool/toolchain is a git repository.


### PR DESCRIPTION
This PR implements the creation of a local `manifest.json`.

After installing a channel, a `manifest.json` file is created. If the channel is the latest stable release at the time of installation, then it is saved with `alias = stable`. 

Example runs: (using [manifest-check-stable.json](https://github.com/0xMiden/midenup/blob/fabrizioorsi/i9-local-manifest/tests/manifest-check-stable.json) as manifest).

```sh
$ midenup install stable
$ cat midenup/manifest.json
{
  "manifest_version": "1.0.0",
  "date": 1750283382,
  "channels": [
    {
      "name": "0.15.0",
      "alias": "stable",
      "components": [
        {
          "name": "std",
          "package": "miden-stdlib",
          "version": "0.15.0"
        },
        {
          "name": "base",
          "package": "miden-lib",
          "version": "0.9.0"
        }
      ]
    }
  ]
}%             
$ midenup install stable
$ cat midenup/manifest.json
{
  "manifest_version": "1.0.0",
  "date": 1750283382,
  "channels": [
    {
      "name": "0.15.0",
      "alias": "stable",
      "components": [
        {
          "name": "std",
          "package": "miden-stdlib",
          "version": "0.15.0"
        },
        {
          "name": "base",
          "package": "miden-lib",
          "version": "0.9.0"
        }
      ]
    },
    {
      "name": "0.14.0",
      "components": [
        {
          "name": "std",
          "package": "miden-stdlib",
          "version": "0.15.0"
        },
        {
          "name": "base",
          "package": "miden-lib",
          "version": "0.9.0"
        }
      ]
    }
  ]
}%                                                       
```

Side-note: This PR builds upon #11.