### PR TITLE
chore: display message after successfull `midenup init` execution

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -53,6 +53,12 @@ pub fn init(config: &Config) -> anyhow::Result<()> {
         bail!("midenup has already been initialized");
     }
 
+    std::println!(
+        "midenup was successfully initialized in:
+{}",
+        config.midenup_home.as_path().display()
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
Closes: #18

Display a small message showing midenup's directory after successful `midenup init` execution