### PR TITLE
feat: add the client to the manifest + `Authority::Git` implementation

### DIFF
--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -24,9 +24,8 @@
         },
         {
           "name": "miden-client",
-          "package": "miden-cli",
-          "version": "0.9.3",
-          "installed_file": "miden"
+          "repository_url": "https://github.com/0xMiden/miden-client.git",
+          "installed_file": "miden-client"
         },
         {
           "name": "midenc",

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -25,6 +25,7 @@
         {
           "name": "miden-client",
           "repository_url": "https://github.com/0xMiden/miden-client.git",
+          "crate_name": "miden-cli",
           "installed_file": "miden-client"
         },
         {

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -26,8 +26,7 @@
           "name": "miden-client",
           "repository_url": "https://github.com/0xMiden/miden-client.git",
           "revision": "83df2aa115b2617e211d1d929a1189ffabbd137b",
-          "crate_name": "miden-client-cli",
-          "installed_file": "miden-client-cli"
+          "crate_name": "miden-client-cli"
         },
         {
           "name": "midenc",

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -25,7 +25,7 @@
         {
           "name": "miden-client",
           "repository_url": "https://github.com/0xMiden/miden-client.git",
-          "branch": "fabrizioorsi/midenup-exe-patch",
+          "revision": "83df2aa115b2617e211d1d929a1189ffabbd137b",
           "crate_name": "miden-client-cli",
           "installed_file": "miden-client-cli"
         },

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -25,8 +25,9 @@
         {
           "name": "miden-client",
           "repository_url": "https://github.com/0xMiden/miden-client.git",
-          "crate_name": "miden-cli",
-          "installed_file": "miden-client"
+          "branch": "fabrizioorsi/midenup-exe-patch",
+          "crate_name": "miden-client-cli",
+          "installed_file": "miden-client-cli"
         },
         {
           "name": "midenc",

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -23,6 +23,12 @@
           "installed_file": "miden"
         },
         {
+          "name": "miden-client",
+          "package": "miden-cli",
+          "version": "0.9.3",
+          "installed_file": "miden"
+        },
+        {
           "name": "midenc",
           "version": "0.1.0",
           "rustup_channel": "nightly-2025-03-20"

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -46,6 +46,8 @@ impl Channel {
             .is_some_and(|alias| matches!(alias, ChannelAlias::Nightly(None)))
     }
 
+    /// This functions compares the Channel &self, with a newer channel [newer]
+    /// and returns the vector of elements that need to be updated.
     pub fn components_to_update(&self, newer: &Self) -> Vec<Component> {
         let new: HashSet<&Component> = HashSet::from_iter(newer.components.iter());
         let current: HashSet<&Component> = HashSet::from_iter(self.components.iter());

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -53,7 +53,7 @@ impl Channel {
     /// and returns the list of [Components] that need to be updated.
     pub fn components_to_update(&self, newer: &Self) -> Vec<Component> {
         let new_channel: HashSet<&Component> = HashSet::from_iter(newer.components.iter());
-        let current: HashSet<&Component> = HashSet::from_iter(self.components.iter());
+        let current = HashSet::from_iter(self.components.iter());
 
         // This is the subset of new components present in the channel since
         // last sync.

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -319,7 +319,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{manifest::Manifest, UserChannel};
+    use crate::{UserChannel, manifest::Manifest};
 
     #[test]
     fn install_script_template_from_local_manifest() {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -115,7 +115,7 @@ fn generate_install_script(channel: &Channel) -> String {
 [dependencies]
 {%- for dep in dependencies %}
 {{ dep.package }} = { version = "{{ dep.version }}"
-{%- if dep.git_uri %}, git = "{{ dep.uri }}"
+{%- if dep.git_uri %}, git = "{{ dep.git_uri }}"
 {%- else if dep.path %}, path = "{{ dep.path }}"
 {%- endif %} }
 {%- endfor %}
@@ -210,7 +210,7 @@ fn main() {
         .get_component("std")
         .expect("Miden standard library is a required component, but isn't available");
     let base = channel
-        .get_component("base")
+        .get_component("miden-lib")
         .expect("Miden transation kernel library is a required component, but isn't available");
     let vm = channel
         .get_component("vm")
@@ -242,7 +242,7 @@ fn main() {
                 upon::value! {
                     package: component.name.clone(),
                     version: "> 0.0.0",
-                    git_uri: format!("{}, {}", repository_url.clone(), target.to_string()),
+                    git_uri: format!("{}\", {target}", repository_url.clone()),
                     path: "",
                 }
             },

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -3,11 +3,12 @@ use std::io::Write;
 use anyhow::Context;
 
 use crate::{
-    Config, bail,
+    bail,
     channel::{Channel, ChannelAlias},
     manifest::Manifest,
     utils,
     version::Authority,
+    Config,
 };
 
 /// Installs a specified toolchain by channel or version.
@@ -217,6 +218,9 @@ fn main() {
     let midenc = channel
         .get_component("midenc")
         .expect("The miden compiler is a required component, but isn't available");
+    let client = channel
+        .get_component("miden-client")
+        .expect("Miden client is a required component, but isn't available");
     let cargo_miden = channel
         .get_component("cargo-miden")
         .expect("The cargo-miden extension is a required component, but isn't available");
@@ -254,7 +258,7 @@ fn main() {
         .collect::<Vec<_>>();
 
     // The set of components to be installed with `cargo install`
-    let installable_components = [vm, cargo_miden, midenc]
+    let installable_components = [vm, cargo_miden, midenc, client]
         .into_iter()
         .map(|component| {
             let mut args = vec![];
@@ -312,7 +316,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{UserChannel, manifest::Manifest};
+    use crate::{manifest::Manifest, UserChannel};
 
     #[test]
     fn install_script_template_from_local_manifest() {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -210,7 +210,7 @@ fn main() {
         .get_component("std")
         .expect("Miden standard library is a required component, but isn't available");
     let base = channel
-        .get_component("miden-lib")
+        .get_component("base")
         .expect("Miden transation kernel library is a required component, but isn't available");
     let vm = channel
         .get_component("vm")
@@ -238,9 +238,9 @@ fn main() {
                     path: "",
                 }
             },
-            Authority::Git { repository_url, target, .. } => {
+            Authority::Git { repository_url, crate_name, target } => {
                 upon::value! {
-                    package: component.name.clone(),
+                    package: crate_name,
                     version: "> 0.0.0",
                     git_uri: format!("{}\", {target}", repository_url.clone()),
                     path: "",

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -3,12 +3,11 @@ use std::io::Write;
 use anyhow::Context;
 
 use crate::{
-    bail,
+    Config, bail,
     channel::{Channel, ChannelAlias},
     manifest::Manifest,
     utils,
     version::{Authority, GitTarget},
-    Config,
 };
 
 /// Installs a specified toolchain by channel or version.
@@ -353,7 +352,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{manifest::Manifest, UserChannel};
+    use crate::{UserChannel, manifest::Manifest};
 
     #[test]
     fn install_script_template_from_local_manifest() {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -75,7 +75,6 @@ pub fn install(
     }
 
     // Update local manifest
-    // -------------------------------------------------------------------------
     let local_manifest_path = config.midenup_home.join("manifest").with_extension("json");
     {
         // Check if the installed channel needs to marked as stable
@@ -90,8 +89,6 @@ pub fn install(
         // If a component was installed with --branch, then write down the
         // current commit. This is used on updates to check if any new commits
         // were pushed since installation.
-        // NOTE: To check the latest commit we're using git cli instead. Would
-        // it be prefereable to use git-rs instead?
         for component in channel_to_save.components.iter_mut() {
             if let Authority::Git {
                 repository_url,

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -238,11 +238,11 @@ fn main() {
                     path: "",
                 }
             },
-            Authority::Git(uri) => {
+            Authority::Git { repository_url } => {
                 upon::value! {
                     package: component.name.clone(),
                     version: "> 0.0.0",
-                    git_uri: uri.clone(),
+                    git_uri: repository_url.clone(),
                     path: "",
                 }
             },
@@ -269,9 +269,9 @@ fn main() {
                     args.push("--version".to_string());
                     args.push(version.to_string());
                 },
-                Authority::Git(repo_uri) => {
+                Authority::Git{repository_url} => {
                     args.push("--git".to_string());
-                    args.push(repo_uri.clone());
+                    args.push(repository_url.clone());
                 },
                 Authority::Path(path) => {
                     args.push("--path".to_string());

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -238,11 +238,11 @@ fn main() {
                     path: "",
                 }
             },
-            Authority::Git { repository_url } => {
+            Authority::Git { repository_url, target, .. } => {
                 upon::value! {
                     package: component.name.clone(),
                     version: "> 0.0.0",
-                    git_uri: repository_url.clone(),
+                    git_uri: format!("{}, {}", repository_url.clone(), target.to_string()),
                     path: "",
                 }
             },
@@ -269,9 +269,12 @@ fn main() {
                     args.push("--version".to_string());
                     args.push(version.to_string());
                 },
-                Authority::Git{repository_url} => {
+                Authority::Git{repository_url, target, crate_name} => {
                     args.push("--git".to_string());
                     args.push(repository_url.clone());
+                    args.push(target.to_cargo_flag()[0].clone());
+                    args.push(target.to_cargo_flag()[1].clone());
+                    args.push(crate_name.clone());
                 },
                 Authority::Path(path) => {
                     args.push("--path".to_string());

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -90,7 +90,7 @@ pub fn install(
 
         // If a component was installed with --branch, then write down the
         // current commit. This is used on updates to check if any new commits
-        // were pushed and the component thus needs to be updated.
+        // were pushed since installation.
         // NOTE: To check the latest commit we're using git cli instead. Would
         // it be prefereable to use git-rs instead?
         for component in channel_to_save.components.iter_mut() {

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -137,6 +137,21 @@ fn update_channel(
                     .wait()
                     .context("failed to uninstall component '{{ component.name }}'")?;
             },
+            Authority::Git { crate_name, .. } => {
+                let mut remove_exe = std::process::Command::new("cargo")
+                    .arg("uninstall")
+                    .arg(crate_name)
+                    .arg("--root")
+                    .arg(&toolchain_dir)
+                    .stderr(std::process::Stdio::inherit())
+                    .stdout(std::process::Stdio::inherit())
+                    .spawn()
+                    .with_context(|| format!("failed to uninstall {crate_name} via cargo"))?;
+
+                remove_exe
+                    .wait()
+                    .context("failed to uninstall component '{{ component.name }}'")?;
+            },
             _ => todo!(),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,6 +260,7 @@ mod tests {
 
         (local_manifest, config)
     }
+
     #[test]
     fn integration_install_stable() {
         let tmp_home = tempdir::TempDir::new("midenup").expect("Couldn't create temp-dir");
@@ -442,6 +443,7 @@ mod tests {
             );
         }
     }
+
     #[test]
     fn integration_rollback_specific_component() {
         let tmp_home = tempdir::TempDir::new("midenup").expect("Couldn't create temp-dir");

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -66,7 +66,7 @@ impl Manifest {
                 return Err(ManifestError::Empty);
             }
             serde_json::from_str::<Manifest>(&contents)
-                .map_err(|_| ManifestError::Invalid(String::from("invalid channel manifest")))
+                .map_err(|e| ManifestError::Invalid(format!("Invalid channel manifest: {e}")))
         } else if uri.starts_with("https://") {
             let mut data = Vec::new();
             let mut handle = curl::easy::Easy::new();
@@ -271,5 +271,37 @@ mod tests {
         );
 
         assert_eq!(stable.alias, Some(ChannelAlias::Tag(Cow::Borrowed("custom-dev-build"))));
+    }
+
+    #[test]
+    fn component_via_git() {
+        const FILE: &str = "file://tests/data/manifest-with-git.json";
+        let manifest = Manifest::load_from(FILE).unwrap();
+
+        let stable = manifest
+            .get_channel(&UserChannel::Other(Cow::Borrowed("custom-dev-build")))
+            .unwrap_or_else(|| {
+                panic!(
+                    "Could not convert UserChannel to internal channel representation from
+        {FILE}"
+                )
+            });
+
+        assert_eq!(
+            stable.name,
+            semver::Version {
+                major: 0,
+                minor: 15,
+                patch: 0,
+                pre: semver::Prerelease::new("custom-dev-build").expect("invalid pre-release"),
+                build: semver::BuildMetadata::EMPTY,
+            }
+        );
+
+        assert_eq!(stable.alias, Some(ChannelAlias::Tag(Cow::Borrowed("custom-dev-build"))));
+
+        let git_component = stable
+            .get_component("miden-client")
+            .unwrap_or_else(|| panic!("Could not find miden-client in {FILE}"));
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -279,7 +279,7 @@ mod tests {
         let manifest = Manifest::load_from(FILE).unwrap();
 
         let stable = manifest
-            .get_channel(&UserChannel::Other(Cow::Borrowed("custom-dev-build")))
+            .get_channel(&UserChannel::Version(semver::Version::new(0, 15, 0)))
             .unwrap_or_else(|| {
                 panic!(
                     "Could not convert UserChannel to internal channel representation from

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -279,7 +279,7 @@ mod tests {
         let manifest = Manifest::load_from(FILE).unwrap();
 
         let stable = manifest
-            .get_channel(&UserChannel::Version(semver::Version::new(0, 15, 0)))
+            .get_channel(&UserChannel::Version(semver::Version::new(0, 14, 0)))
             .unwrap_or_else(|| {
                 panic!(
                     "Could not convert UserChannel to internal channel representation from
@@ -300,8 +300,12 @@ mod tests {
 
         assert_eq!(stable.alias, Some(ChannelAlias::Tag(Cow::Borrowed("custom-dev-build"))));
 
-        let git_component = stable
+        let client_via_git = stable
             .get_component("miden-client")
+            .unwrap_or_else(|| panic!("Could not find miden-client in {FILE}"));
+
+        let miden_lib_via_git = stable
+            .get_component("base")
             .unwrap_or_else(|| panic!("Could not find miden-client in {FILE}"));
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -279,7 +279,7 @@ mod tests {
         let manifest = Manifest::load_from(FILE).unwrap();
 
         let stable = manifest
-            .get_channel(&UserChannel::Version(semver::Version::new(0, 14, 0)))
+            .get_channel(&UserChannel::Version(semver::Version::new(0, 15, 0)))
             .unwrap_or_else(|| {
                 panic!(
                     "Could not convert UserChannel to internal channel representation from
@@ -293,18 +293,18 @@ mod tests {
                 major: 0,
                 minor: 15,
                 patch: 0,
-                pre: semver::Prerelease::new("custom-dev-build").expect("invalid pre-release"),
+                pre: semver::Prerelease::EMPTY,
                 build: semver::BuildMetadata::EMPTY,
             }
         );
 
-        assert_eq!(stable.alias, Some(ChannelAlias::Tag(Cow::Borrowed("custom-dev-build"))));
+        assert_eq!(stable.alias, None);
 
-        let client_via_git = stable
+        let _client_via_git = stable
             .get_component("miden-client")
             .unwrap_or_else(|| panic!("Could not find miden-client in {FILE}"));
 
-        let miden_lib_via_git = stable
+        let _miden_lib_via_git = stable
             .get_component("base")
             .unwrap_or_else(|| panic!("Could not find miden-client in {FILE}"));
     }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -34,6 +34,7 @@ impl Default for Toolchain {
                 "std".to_string(),
                 "base".to_string(),
                 "vm".to_string(),
+                "miden-client".to_string(),
                 "midenc".to_string(),
                 "cargo-miden".to_string(),
             ],

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,3 +9,27 @@ pub fn symlink(from: &std::path::Path, to: &std::path::Path) -> anyhow::Result<(
 pub fn symlink(from: &std::path::Path, to: &std::path::Path) -> anyhow::Result<()> {
     std::os::windows::fs::symlink_file(to, from).context("could not create symlink")
 }
+
+pub fn find_latest_hash(repository_url: &str, branch_name: &str) -> anyhow::Result<String> {
+    let check_revision_hash = std::process::Command::new("git")
+        .arg("ls-remote")
+        .arg(repository_url)
+        .arg("--branch")
+        .arg(branch_name)
+        .stderr(std::process::Stdio::inherit())
+        .stdout(std::process::Stdio::piped())
+        .output()
+        .context(format!(
+            "failed to fetch latest git rev-hash from branch {branch_name}, is git installed?.",
+        ))?;
+
+    let revision_hash: String = String::from_utf8(check_revision_hash.stdout)
+        .context(format!(
+            "failed to format latest git rev-hash from branch {branch_name}, does the branch exist?.",
+        ))?
+        .chars()
+        .take_while(|&c| c != ' ' && c != '\t')
+        .collect();
+
+    Ok(revision_hash)
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,12 +23,15 @@ pub fn find_latest_hash(repository_url: &str, branch_name: &str) -> anyhow::Resu
             "failed to fetch latest git rev-hash from branch {branch_name}, is git installed?.",
         ))?;
 
+    // This returns a string of the form:
+    // sym_ref\tref_name
+    // Source: https://github.com/git/git/blob/41905d60226a0346b22f0d0d99428c746a5a3b14/builtin/ls-remote.c#L169
     let revision_hash: String = String::from_utf8(check_revision_hash.stdout)
         .context(format!(
             "failed to format latest git rev-hash from branch {branch_name}, does the branch exist?.",
         ))?
         .chars()
-        .take_while(|&c| c != ' ' && c != '\t')
+        .take_while(|&c| c != '\t')
         .collect();
 
     Ok(revision_hash)

--- a/src/version.rs
+++ b/src/version.rs
@@ -111,7 +111,7 @@ pub enum Authority {
     #[serde(untagged)]
     Cargo {
         /// The name of the crates.io package under which this tool is provided
-        /// In None, then the package's name is the same as the component's
+        /// If None, then the package's name is the same as the component's
         #[serde(skip_serializing_if = "Option::is_none")]
         package: Option<String>,
         /// The semantic versioning string for the package to fetch

--- a/src/version.rs
+++ b/src/version.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 /// Used to specify a particular revision of a repository.
 #[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
 pub enum GitTarget {
     Branch(String),
     Revision(String),
@@ -52,7 +53,7 @@ pub enum Authority {
         crate_name: String,
         /// NOTE: If the target is missing from the [Manifest], then we assume
         /// that it is pointing to the tip of the `main` branch
-        #[serde(default)]
+        #[serde(default, flatten)]
         target: GitTarget,
     },
     /// The authority for this tool/toolchain is crates.io

--- a/src/version.rs
+++ b/src/version.rs
@@ -21,7 +21,7 @@ impl fmt::Display for GitTarget {
         match &self {
             GitTarget::Branch(branch_name) => write!(f, "branch = {branch_name}"),
             GitTarget::Revision(hash) => write!(f, "rev = {hash}"),
-            GitTarget::Tag(tag) => write!(f, "tag = {tag}"),
+            GitTarget::Tag(tag) => write!(f, "tag = \"{tag}"),
         }
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "snake_case")]
 pub enum Authority {
     /// The authority for this tool/toolchain is a git repository.
-    Git(String),
+    Git { repository_url: String },
     /// The authority for this tool/toolchain is a local filesystem path
     Path(PathBuf),
     /// The authority for this tool/toolchain is crates.io
@@ -26,7 +26,7 @@ impl fmt::Display for Authority {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             Authority::Cargo { version, .. } => write!(f, "{version}"),
-            Authority::Git(repo) => write!(f, "{repo}"),
+            Authority::Git { repository_url } => write!(f, "{repository_url}"),
             Authority::Path(path) => write!(f, "{}", path.display()),
         }
     }

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,25 +1,76 @@
-use std::{fmt, path::PathBuf};
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    path::PathBuf,
+};
 
 use serde::{Deserialize, Serialize};
 
-/// Used to specify a particular revision of a repository.
-#[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
+/// Used to specify from which  particular revision of a repository.
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum GitTarget {
-    Branch(String),
+    /// The components is pointing to a specific revision in the repository.
     Revision(String),
+    /// The components is pointing to a specific tag in the repository.
     Tag(String),
+    #[serde(untagged)]
+    /// The components is pointing to a specific *branch* in the repository.
+    /// NOTE: When an update is issued, these type of components will trigger an
+    /// update if the branch they were pointing to had new commits since the
+    /// time the component was installed. This means that these components are
+    /// *not* deterministic and their behavior could change in-between updates.
+    Branch {
+        #[serde(rename = "branch")]
+        /// This is the name of the branch being tracked.
+        name: String,
+        /// This field represents the revision hash that is currently presently
+        /// installed. This is only meant to be used in the local manifest in
+        /// order to check for updates.
+        latest_revision: Option<String>,
+    },
 }
 impl Default for GitTarget {
     fn default() -> Self {
-        GitTarget::Branch(String::from("main"))
+        GitTarget::Branch {
+            name: String::from("main"),
+            latest_revision: None,
+        }
+    }
+}
+impl Eq for GitTarget {}
+impl PartialEq for GitTarget {
+    fn eq(&self, other: &Self) -> bool {
+        match (&self, other) {
+            (Self::Revision(hasha), Self::Revision(hashb)) => hasha == hashb,
+            (Self::Tag(taga), Self::Tag(tagb)) => taga == tagb,
+            // Two components are "equal" if they are pointing to the same
+            // branch. Comparison between latest available commit is done ad-hoc
+            (Self::Branch { name: name_a, .. }, Self::Branch { name: name_b, .. }) => {
+                name_a == name_b
+            },
+            _ => false,
+        }
+    }
+}
+
+impl Hash for GitTarget {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        match &self {
+            Self::Revision(hash_a) => hash_a.hash(state),
+            Self::Tag(tag_a) => tag_a.hash(state),
+            Self::Branch { name, .. } => name.hash(state),
+        }
     }
 }
 
 impl fmt::Display for GitTarget {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
-            GitTarget::Branch(branch_name) => write!(f, "branch = {branch_name}"),
+            GitTarget::Branch { name, .. } => write!(f, "branch = {name}"),
             GitTarget::Revision(hash) => write!(f, "rev = {hash}"),
             GitTarget::Tag(tag) => write!(f, "tag = \"{tag}"),
         }
@@ -29,7 +80,7 @@ impl fmt::Display for GitTarget {
 impl GitTarget {
     pub fn to_cargo_flag(&self) -> [String; 2] {
         match &self {
-            GitTarget::Branch(branch_name) => [String::from("--branch"), String::from(branch_name)],
+            GitTarget::Branch { name, .. } => [String::from("--branch"), String::from(name)],
             GitTarget::Revision(hash) => [String::from("--rev"), String::from(hash)],
             GitTarget::Tag(tag) => [String::from("--tag"), String::from(tag)],
         }

--- a/src/version.rs
+++ b/src/version.rs
@@ -6,10 +6,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum Authority {
-    /// The authority for this tool/toolchain is a git repository.
-    Git { repository_url: String },
     /// The authority for this tool/toolchain is a local filesystem path
     Path(PathBuf),
+    /// The authority for this tool/toolchain is a git repository.
+    #[serde(untagged)]
+    Git { repository_url: String },
     /// The authority for this tool/toolchain is crates.io
     #[serde(untagged)]
     Cargo {

--- a/tests/data/manifest-with-git.json
+++ b/tests/data/manifest-with-git.json
@@ -11,7 +11,7 @@
           "version": "0.14.0"
         },
         {
-          "name": "miden-lib",
+          "name": "base",
           "repository_url": "https://github.com/0xMiden/miden-base.git",
           "tag": "v0.9.0",
           "crate_name": "miden-lib"

--- a/tests/data/manifest-with-git.json
+++ b/tests/data/manifest-with-git.json
@@ -1,0 +1,45 @@
+{
+  "manifest_version": "1.0",
+  "date": 1745931671,
+  "channels": [
+    {
+      "name": "0.14.0",
+      "components": [
+        {
+          "name": "std",
+          "package": "miden-stdlib",
+          "version": "0.14.0"
+        },
+        {
+          "name": "miden-lib",
+          "repository_url": "https://github.com/0xMiden/miden-base.git",
+          "tag": "v0.9.0",
+          "crate_name": "miden-lib"
+        },
+        {
+          "name": "vm",
+          "package": "miden-vm",
+          "version": "0.15.0",
+          "features": ["executable", "concurrent"]
+        },
+        {
+          "name": "miden-client",
+          "repository_url": "https://github.com/0xMiden/miden-client.git",
+          "branch": "fabrizioorsi/midenup-exe-patch",
+          "crate_name": "miden-client-cli",
+          "installed_file": "miden-client-cli"
+        },
+        {
+          "name": "midenc",
+          "version": "0.1.0",
+          "rustup_channel": "nightly-2025-03-20"
+        },
+        {
+          "name": "cargo-miden",
+          "version": "0.1.0",
+          "rustup_channel": "nightly-2025-03-20"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/data/manifest-with-git.json
+++ b/tests/data/manifest-with-git.json
@@ -3,7 +3,7 @@
   "date": 1745931671,
   "channels": [
     {
-      "name": "0.14.0",
+      "name": "0.15.0",
       "components": [
         {
           "name": "std",

--- a/tests/data/rollback-component/manifest-post-component-rollback.json
+++ b/tests/data/rollback-component/manifest-post-component-rollback.json
@@ -16,6 +16,13 @@
           "version": "0.9.0"
         },
         {
+          "name": "miden-client",
+          "repository_url": "https://github.com/0xMiden/miden-client.git",
+          "branch": "fabrizioorsi/midenup-exe-patch",
+          "crate_name": "miden-client-cli",
+          "installed_file": "miden-client-cli"
+        },
+        {
           "name": "vm",
           "package": "miden-vm",
           "version": "0.15.0",

--- a/tests/data/rollback-component/manifest-pre-component-rollback.json
+++ b/tests/data/rollback-component/manifest-pre-component-rollback.json
@@ -16,6 +16,13 @@
           "version": "0.9.0"
         },
         {
+          "name": "miden-client",
+          "repository_url": "https://github.com/0xMiden/miden-client.git",
+          "branch": "fabrizioorsi/midenup-exe-patch",
+          "crate_name": "miden-client-cli",
+          "installed_file": "miden-client-cli"
+        },
+        {
           "name": "vm",
           "package": "miden-vm",
           "version": "0.15.0",

--- a/tests/data/update-specific/manifest-post-component-update.json
+++ b/tests/data/update-specific/manifest-post-component-update.json
@@ -22,6 +22,13 @@
           "features": ["executable", "concurrent"]
         },
         {
+          "name": "miden-client",
+          "repository_url": "https://github.com/0xMiden/miden-client.git",
+          "branch": "fabrizioorsi/midenup-exe-patch",
+          "crate_name": "miden-client-cli",
+          "installed_file": "miden-client-cli"
+        },
+        {
           "name": "midenc",
           "version": "0.1.0",
           "rustup_channel": "nightly-2025-03-20"

--- a/tests/data/update-specific/manifest-pre-component-update.json
+++ b/tests/data/update-specific/manifest-pre-component-update.json
@@ -22,6 +22,13 @@
           "features": ["executable", "concurrent"]
         },
         {
+          "name": "miden-client",
+          "repository_url": "https://github.com/0xMiden/miden-client.git",
+          "branch": "fabrizioorsi/midenup-exe-patch",
+          "crate_name": "miden-client-cli",
+          "installed_file": "miden-client-cli"
+        },
+        {
           "name": "midenc",
           "version": "0.1.0",
           "rustup_channel": "nightly-2025-03-20"

--- a/tests/data/update-stable/manifest-post-update.json
+++ b/tests/data/update-stable/manifest-post-update.json
@@ -11,6 +11,13 @@
           "version": "0.15.0"
         },
         {
+          "name": "miden-client",
+          "repository_url": "https://github.com/0xMiden/miden-client.git",
+          "branch": "fabrizioorsi/midenup-exe-patch",
+          "crate_name": "miden-client-cli",
+          "installed_file": "miden-client-cli"
+        },
+        {
           "name": "base",
           "package": "miden-lib",
           "version": "0.9.0"

--- a/tests/data/update-stable/manifest-pre-update.json
+++ b/tests/data/update-stable/manifest-pre-update.json
@@ -16,6 +16,13 @@
           "version": "0.9.0"
         },
         {
+          "name": "miden-client",
+          "repository_url": "https://github.com/0xMiden/miden-client.git",
+          "branch": "fabrizioorsi/midenup-exe-patch",
+          "crate_name": "miden-client-cli",
+          "installed_file": "miden-client-cli"
+        },
+        {
           "name": "vm",
           "package": "miden-vm",
           "version": "0.15.0",


### PR DESCRIPTION
Closes #26 
Closes #35 

This PR adds the Miden client to the manifest and also adds the implementation for components behind `Authority::Git`

Notes on this PR:
- The manifest now holds the `miden-client`, but it is tracked via a specific commit. This is done in order to guarantee a component that is not susceptible to changes (since it is not a desired behavior).   
- `Authority::Git` supports three different targets: tags, revisions and branches
- When an update is triggered, components behind branches will check if there have been any new commits since (this is done via the `git ls-remote` command). If so, an update is issued. 
