### PR TITLE
docs: add missing documentation

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, bail};
+use anyhow::Context;
 
 use crate::{Config, utils};
 
@@ -7,7 +7,6 @@ use crate::{Config, utils};
 ///
 /// - Bootstrap the `midenup` environment (create directories, default config, etc.), if not already
 ///   done.
-/// - Install the stable channel
 pub fn init(config: &Config) -> anyhow::Result<()> {
     // Create the data directory layout.
     //
@@ -62,11 +61,6 @@ pub fn init(config: &Config) -> anyhow::Result<()> {
                 toolchains_dir.display()
             )
         })?;
-    }
-
-    let default_toolchain_dir = toolchains_dir.join("stable");
-    if default_toolchain_dir.exists() {
-        bail!("midenup has already been initialized");
     }
 
     std::println!(

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -152,6 +152,9 @@ pub fn install(
     Ok(())
 }
 
+/// This function generates the install script that will later be saved in
+/// `midenup/toolchains/<version>/install.rs`. This file is then executed by
+/// `cargo -Zscript`.
 fn generate_install_script(channel: &Channel) -> String {
     // Prepare install script template
     let engine = upon::Engine::new();

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -10,6 +10,9 @@ use crate::{
 
 const TOOLCHAIN_FILE_NAME: &str = "miden-toolchain.toml";
 
+/// This function creates the [miden-toolchain.toml] in the present working
+/// directory. This file contains the desired [Toolchain] with a list of the
+/// components that make it up.
 pub fn set(config: &Config, channel: &UserChannel) -> anyhow::Result<()> {
     let toolchain_file_path =
         config.working_directory.join(TOOLCHAIN_FILE_NAME).with_extension("toml");

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -83,6 +83,11 @@ midenup install stable
     Ok(())
 }
 
+/// This function executes the actual update. It is in charge of "preparing the
+/// environmet" to then call [commands::install]. That preparation mainly
+/// consists of:
+/// - Uninstalls components (via cargo uninstall).
+/// - Removes the installation indicator file.
 fn update_channel(
     config: &Config,
     local_channel: &Channel,

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,7 @@ enum Behavior {
     Miden(Vec<OsString>),
 }
 
+/// All the available Midenup Commands
 #[derive(Debug, Subcommand)]
 enum Commands {
     /// Bootstrap the `midenup` environment.
@@ -59,15 +60,19 @@ enum Commands {
     #[command(subcommand)]
     Show(commands::ShowCommand),
     /// Sets the current active miden toolchain for the current project.
-    /// This creates a miden-toolchain.toml file.
+    /// This creates a miden-toolchain.toml file in the present working directory.
     Set {
         /// The channel or version to set, e.g. `stable` or `0.15.0`
         #[arg(required(true), value_name = "CHANNEL", value_parser)]
         channel: UserChannel,
     },
-    /// Update your installed Miden toolchains
+    /// Update your installed Miden toolchains.
     Update {
-        /// If provided, updates only the specified channel.
+        /// `midenup update`'s behavior differs depending on the specified [CHANNEL]
+        /// - If provided, updates only the specified channel.
+        /// - If left blank, then midenup will check for updates in all the downloaded toolchains.
+        /// - If [CHANNEL] = stable, then it will look for the newest available toolchain and set
+        ///   that to be stable.
         #[arg(value_name = "CHANNEL", value_parser)]
         channel: Option<UserChannel>,
     },
@@ -95,7 +100,7 @@ impl Commands {
     /// Execute the requested subcommand
     fn execute(&self, config: &Config, local_manifest: &mut Manifest) -> anyhow::Result<()> {
         match &self {
-            Self::Init { .. } => commands::init(config),
+            Self::Init => commands::init(config),
             Self::Install { channel, .. } => {
                 let Some(channel) = config.manifest.get_channel(channel) else {
                     bail!("channel '{}' doesn't exist or is unavailable", channel);
@@ -288,6 +293,8 @@ mod tests {
     type LocalManifest = Manifest;
     use crate::{channel::*, manifest::*, *};
 
+    /// Simple auxiliary function to setup a midneup directory environment in
+    /// tests.
     fn test_setup(midenup_home: &Path, manifest_uri: &str) -> (LocalManifest, Config) {
         let local_manifest = {
             let local_manifest_path = midenup_home.join("manifest").with_extension("json");
@@ -319,6 +326,7 @@ mod tests {
     }
 
     #[test]
+    /// Tries to install the "stable" toolchain from the present manifest.
     fn integration_install_stable() {
         let tmp_home = tempdir::TempDir::new("midenup").expect("Couldn't create temp-dir");
         let tmp_home_path = tmp_home.path();
@@ -366,6 +374,9 @@ mod tests {
     }
 
     #[test]
+    /// First, use a manifest file to install the stable toolchain under version
+    /// 0.14.0. Then, update said manifest and try to update stable to the newer
+    /// version
     fn integration_update_stable() {
         // NOTE: Currentlty "update stable" maintains the old stable toolchain
         let tmp_home = tempdir::TempDir::new("midenup").expect("Couldn't create temp-dir");
@@ -436,6 +447,10 @@ mod tests {
     }
 
     #[test]
+    /// First, use a manifest file to install the version 0.14.0.  Then, use a
+    /// newer manifest to display an update in the std component and a downgrade
+    /// in base. After triggering an update, check if those components got
+    /// updated successfully.
     fn integration_update_specific_component() {
         let tmp_home = tempdir::TempDir::new("midenup").expect("Couldn't create temp-dir");
         let tmp_home_path = tmp_home.path();
@@ -502,6 +517,8 @@ mod tests {
     }
 
     #[test]
+    /// Install a specific component and then try to check if midenup update
+    /// registers it got rolled back
     fn integration_rollback_specific_component() {
         let tmp_home = tempdir::TempDir::new("midenup").expect("Couldn't create temp-dir");
         let tmp_home_path = tmp_home.path();

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -16,7 +16,6 @@ pub struct Manifest {
     /// The UTC timestamp at which this manifest was generated
     date: i64,
     /// The channels described in this manifest
-    /// NOTE: Changing this to pub momentarily
     channels: Vec<Channel>,
 }
 
@@ -54,7 +53,7 @@ impl Manifest {
         "https://0xmiden.github.io/midenup/channel-manifest.json";
     pub const LOCAL_MANIFEST_URI: &str = "https://0xmiden.github.io/midenup/channel-manifest.json";
 
-    /// Loads a [Manifest] from the given URI
+    /// Loads a [Manifest] from the given URI.
     pub fn load_from(uri: impl AsRef<str>) -> Result<Manifest, ManifestError> {
         let uri = uri.as_ref();
         let manifest = if let Some(manifest_path) = uri.strip_prefix("file://") {
@@ -136,6 +135,10 @@ impl Manifest {
 
         self.channels.push(channel);
     }
+
+    /// Determines whether the `channel` is the latest stable version. This can
+    /// only be determined by the [Manifest], since this definition is dependant
+    /// on all the other present [Channels]
     pub fn is_latest_stable(&self, channel: &Channel) -> bool {
         self.channels.iter().filter(|c| c.is_stable()).all(|c| {
             let comparison = channel.name.cmp_precedence(&c.name);
@@ -143,8 +146,8 @@ impl Manifest {
         })
     }
 
-    /// Attempts to fetch the version corresponding to the `stable` [Channel], by definition this is
-    /// the latest version
+    /// Attempts to fetch the version corresponding to the `stable` [Channel],
+    /// by definition this is the latest version.
     pub fn get_latest_stable(&self) -> Option<&Channel> {
         self.channels
             .iter()

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -3,13 +3,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::channel::UserChannel;
 
-/// Represents a `miden-toolchain.toml` file
+/// Represents a `miden-toolchain.toml` file. These file contains the desired
+/// toolchain to be used.
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct ToolchainFile {
     toolchain: Toolchain,
 }
 
-/// The actual contents of the toolchain
+/// The actual contents of the toolchain.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Toolchain {
     pub channel: UserChannel,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,4 @@
+/// This file contains some general purpose functions.
 use anyhow::Context;
 
 #[cfg(unix)]


### PR DESCRIPTION
Closes: #48

This PR adds some missing documentation to various structures and functions in `midenup`.