### PR TITLE
refactor: separate `commands::init` into two separate functions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -54,9 +54,6 @@ jobs:
       - name: Mark midenup it as executable
         run: |
           chmod +x midenup
-      - name: initialize midenup directory
-        run: |
-          ./midenup init
       - name: install stable
         run: |
           ./midenup install stable

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,27 +1,18 @@
-use anyhow::Context;
-
-use crate::{commands, config::ensure_midenup_home_exists, manifest::Manifest, Config};
+use crate::{config::ensure_midenup_home_exists, manifest::Manifest, Config};
 
 /// This is the first command the user runs after first installing the midenup. It performs the
 /// following tasks:
 ///
 /// - Bootstrap the `midenup` environment (create directories, default config, etc.), if not already
 ///   done. (done in [ensure_midenup_home_exists]).
-/// - Install the stable channel.
-pub fn init(config: &Config, local_manifest: &mut Manifest) -> anyhow::Result<()> {
+pub fn init(config: &Config, _local_manifest: &mut Manifest) -> anyhow::Result<()> {
     ensure_midenup_home_exists(config)?;
 
-    let toolchains_dir = config.midenup_home.join("toolchains");
-    let stable = toolchains_dir.join("stable");
-    if !stable.exists() {
-        std::println!("About to install stable toolchain");
-
-        let upstream_stable = config
-            .manifest
-            .get_latest_stable()
-            .context("ERROR: No stable channel found in upstream")?;
-        commands::install(config, upstream_stable, local_manifest)?;
-    }
+    println!(
+        "midenup was successfully initialized in:
+{}",
+        config.midenup_home.as_path().display()
+    );
 
     Ok(())
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -31,12 +31,14 @@ pub fn init(config: &Config) -> anyhow::Result<()> {
         })?;
     }
     let local_manifest_file = config.midenup_home.join("manifest").with_extension("json");
-    std::fs::File::create(&local_manifest_file).with_context(|| {
-        format!(
-            "failed to create local manifest.json file in: '{}'",
-            local_manifest_file.display()
-        )
-    })?;
+    if !local_manifest_file.exists() {
+        std::fs::File::create(&local_manifest_file).with_context(|| {
+            format!(
+                "failed to create local manifest.json file in: '{}'",
+                local_manifest_file.display()
+            )
+        })?;
+    }
 
     let bin_dir = config.midenup_home.join("bin");
     if !bin_dir.exists() {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,18 +1,88 @@
-use crate::{config::ensure_midenup_home_exists, manifest::Manifest, Config};
+use anyhow::Context;
 
-/// This is the first command the user runs after first installing the midenup. It performs the
-/// following tasks:
+use crate::{Config, utils};
+
+/// This functions bootstrap the `midenup` environment (creates basic directory
+/// structure, creates the miden executable symlink, etc.), if not already
+/// initialized.
+/// NOTE: An environment is considered to be "uninitialized" if *at least* one element
+/// (be it a file, directory, etc) is missing,
 ///
-/// - Bootstrap the `midenup` environment (create directories, default config, etc.), if not already
-///   done. (done in [ensure_midenup_home_exists]).
-pub fn init(config: &Config, _local_manifest: &mut Manifest) -> anyhow::Result<()> {
-    ensure_midenup_home_exists(config)?;
+/// The following is a sketch of the directory tree and contents
+///
+/// $MIDENUP_HOME
+/// |- bin/
+/// | |- miden --> $CARGO_INSTALL_DIR/midenup
+/// |- toolchains
+/// | |- stable/ --> <channel>/
+/// | |- <channel>/
+/// | | |- bin/
+/// | | |- lib/
+/// | | | |- std.masp
+/// |- config.toml
+/// |- manifest.json
+pub fn init(config: &Config) -> anyhow::Result<()> {
+    let mut already_exists = true;
 
-    println!(
-        "midenup was successfully initialized in:
+    let midenhome_dir = &config.midenup_home;
+    if !midenhome_dir.exists() {
+        std::fs::create_dir_all(midenhome_dir).with_context(|| {
+            format!("failed to initialize MIDENUP_HOME directory: '{}'", midenhome_dir.display())
+        })?;
+        already_exists = false;
+    }
+    let local_manifest_file = config.midenup_home.join("manifest").with_extension("json");
+    if !local_manifest_file.exists() {
+        std::fs::File::create(&local_manifest_file).with_context(|| {
+            format!(
+                "failed to create local manifest.json file in: '{}'",
+                local_manifest_file.display()
+            )
+        })?;
+        already_exists = false;
+    }
+
+    let bin_dir = config.midenup_home.join("bin");
+    if !bin_dir.exists() {
+        std::fs::create_dir_all(&bin_dir).with_context(|| {
+            format!("failed to initialize MIDENUP_HOME subdirectory: '{}'", bin_dir.display())
+        })?;
+        already_exists = false;
+    }
+
+    // Write the symlink for `miden` to $MIDENUP_HOME/bin
+    let current_exe =
+        std::env::current_exe().expect("unable to get location of current executable");
+    let miden_exe = bin_dir.join("miden");
+    if !miden_exe.exists() {
+        utils::symlink(&miden_exe, &current_exe)?;
+        already_exists = false;
+    }
+
+    let toolchains_dir = config.midenup_home.join("toolchains");
+    if !toolchains_dir.exists() {
+        std::fs::create_dir_all(&toolchains_dir).with_context(|| {
+            format!(
+                "failed to initialize MIDENUP_HOME subdirectory: '{}'",
+                toolchains_dir.display()
+            )
+        })?;
+        already_exists = false;
+    }
+
+    if !already_exists {
+        std::println!(
+            "midenup was successfully initialized in:
 {}",
-        config.midenup_home.as_path().display()
-    );
+            config.midenup_home.as_path().display()
+        );
+    } else {
+        std::println!(
+            "midenup already initialized in:
+{}",
+            config.midenup_home.as_path().display()
+        );
+    }
 
     Ok(())
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 
-use crate::{Config, utils};
+use crate::{utils, Config};
 
 /// This is the first command the user runs after first installing the midenup. It performs the
 /// following tasks:

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,75 +1,27 @@
 use anyhow::Context;
 
-use crate::{utils, Config};
+use crate::{commands, config::ensure_midenup_home_exists, manifest::Manifest, Config};
 
 /// This is the first command the user runs after first installing the midenup. It performs the
 /// following tasks:
 ///
 /// - Bootstrap the `midenup` environment (create directories, default config, etc.), if not already
-///   done.
-pub fn init(config: &Config) -> anyhow::Result<()> {
-    // Create the data directory layout.
-    //
-    // The following is a sketch of the directory tree and contents
-    //
-    // $MIDENUP_HOME
-    // |- bin/
-    // | |- miden --> $CARGO_INSTALL_DIR/midenup
-    // |- toolchains
-    // | |- stable/ --> <channel>/
-    // | |- <channel>/
-    // | | |- bin/
-    // | | |- lib/
-    // | | | |- std.masp
-    // |- config.toml
-    // |- manifest.json
-
-    let midenhome_dir = &config.midenup_home;
-    if !midenhome_dir.exists() {
-        std::fs::create_dir_all(midenhome_dir).with_context(|| {
-            format!("failed to initialize MIDENUP_HOME directory: '{}'", midenhome_dir.display())
-        })?;
-    }
-    let local_manifest_file = config.midenup_home.join("manifest").with_extension("json");
-    if !local_manifest_file.exists() {
-        std::fs::File::create(&local_manifest_file).with_context(|| {
-            format!(
-                "failed to create local manifest.json file in: '{}'",
-                local_manifest_file.display()
-            )
-        })?;
-    }
-
-    let bin_dir = config.midenup_home.join("bin");
-    if !bin_dir.exists() {
-        std::fs::create_dir_all(&bin_dir).with_context(|| {
-            format!("failed to initialize MIDENUP_HOME subdirectory: '{}'", bin_dir.display())
-        })?;
-    }
-
-    // Write the symlink for `miden` to $MIDENUP_HOME/bin
-    let current_exe =
-        std::env::current_exe().expect("unable to get location of current executable");
-    let miden_exe = bin_dir.join("miden");
-    if !miden_exe.exists() {
-        utils::symlink(&miden_exe, &current_exe)?;
-    }
+///   done. (done in [ensure_midenup_home_exists]).
+/// - Install the stable channel.
+pub fn init(config: &Config, local_manifest: &mut Manifest) -> anyhow::Result<()> {
+    ensure_midenup_home_exists(config)?;
 
     let toolchains_dir = config.midenup_home.join("toolchains");
-    if !toolchains_dir.exists() {
-        std::fs::create_dir_all(&toolchains_dir).with_context(|| {
-            format!(
-                "failed to initialize MIDENUP_HOME subdirectory: '{}'",
-                toolchains_dir.display()
-            )
-        })?;
-    }
+    let stable = toolchains_dir.join("stable");
+    if !stable.exists() {
+        std::println!("About to install stable toolchain");
 
-    std::println!(
-        "midenup was successfully initialized in:
-{}",
-        config.midenup_home.as_path().display()
-    );
+        let upstream_stable = config
+            .manifest
+            .get_latest_stable()
+            .context("ERROR: No stable channel found in upstream")?;
+        commands::install(config, upstream_stable, local_manifest)?;
+    }
 
     Ok(())
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -5,6 +5,7 @@ use anyhow::Context;
 use crate::{
     Config, bail,
     channel::{Channel, ChannelAlias},
+    config::ensure_midenup_home_exists,
     manifest::Manifest,
     utils,
     version::{Authority, GitTarget},
@@ -20,7 +21,7 @@ pub fn install(
     channel: &Channel,
     local_manifest: &mut Manifest,
 ) -> anyhow::Result<()> {
-    config.ensure_midenup_home_exists()?;
+    ensure_midenup_home_exists(config)?;
 
     let installed_toolchains_dir = config.midenup_home.join("toolchains");
     let toolchain_dir = installed_toolchains_dir.join(format!("{}", &channel.name));

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -5,7 +5,7 @@ use anyhow::Context;
 use crate::{
     Config, bail,
     channel::{Channel, ChannelAlias},
-    config::ensure_midenup_home_exists,
+    commands,
     manifest::Manifest,
     utils,
     version::{Authority, GitTarget},
@@ -21,7 +21,7 @@ pub fn install(
     channel: &Channel,
     local_manifest: &mut Manifest,
 ) -> anyhow::Result<()> {
-    ensure_midenup_home_exists(config)?;
+    commands::init(config)?;
 
     let installed_toolchains_dir = config.midenup_home.join("toolchains");
     let toolchain_dir = installed_toolchains_dir.join(format!("{}", &channel.name));

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -27,7 +27,7 @@ pub fn set(config: &Config, channel: &UserChannel) -> anyhow::Result<()> {
         match std::fs::read_to_string(current_components_list) {
             Ok(components) => components,
             Err(_) => {
-                std::println!(
+                println!(
                     "WARNING: Non present toolchain was set. Component list will be left empty"
                 );
                 String::default()

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -45,6 +45,8 @@ pub fn set(config: &Config, channel: &UserChannel) -> anyhow::Result<()> {
     let toolchain_file_contents = toml::to_string_pretty(&installed_toolchain)
         .context("Failed to generate miden-toolchain.toml")?;
 
-    toolchain_file.write_all(&toolchain_file_contents.into_bytes()).unwrap();
+    toolchain_file
+        .write_all(&toolchain_file_contents.into_bytes())
+        .context("Failed to write miden-toolchain.toml")?;
     Ok(())
 }

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -3,9 +3,9 @@ use std::io::Write;
 use anyhow::Context;
 
 use crate::{
+    Config,
     channel::UserChannel,
     toolchain::{Toolchain, ToolchainFile},
-    Config,
 };
 
 const TOOLCHAIN_FILE_NAME: &str = "miden-toolchain.toml";

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -25,7 +25,7 @@ pub fn set(config: &Config, channel: &UserChannel) -> anyhow::Result<()> {
 
     let components = {
         match std::fs::read_to_string(current_components_list) {
-            Ok(componets) => componets,
+            Ok(components) => components,
             Err(_) => {
                 std::println!(
                     "WARNING: Non present toolchain was set. Component list will be left empty"

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -3,9 +3,9 @@ use std::io::Write;
 use anyhow::Context;
 
 use crate::{
-    Config,
     channel::UserChannel,
     toolchain::{Toolchain, ToolchainFile},
+    Config,
 };
 
 const TOOLCHAIN_FILE_NAME: &str = "miden-toolchain.toml";
@@ -23,7 +23,17 @@ pub fn set(config: &Config, channel: &UserChannel) -> anyhow::Result<()> {
         .join(channel.to_string())
         .join("installation-successful");
 
-    let components = std::fs::read_to_string(current_components_list).unwrap();
+    let components = {
+        match std::fs::read_to_string(current_components_list) {
+            Ok(componets) => componets,
+            Err(_) => {
+                std::println!(
+                    "WARNING: Non present toolchain was set. Component list will be left empty"
+                );
+                String::default()
+            },
+        }
+    };
     let components: Vec<String> = components.lines().map(String::from).collect();
 
     let installed_toolchain = Toolchain::new(channel.clone(), components);

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -35,7 +35,7 @@ midenup install stable
             if upstream_stable.name > local_stable.name {
                 commands::install(config, upstream_stable, local_manifest)?
             } else {
-                std::println!("Nothing to update, you are all up to date");
+                println!("Nothing to update, you are all up to date");
             }
         },
         Some(UserChannel::Version(version)) => {

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -6,6 +6,7 @@ use crate::{
     Config,
     channel::{Channel, UserChannel},
     commands,
+    commands::install::DEPENDENCIES,
     manifest::Manifest,
     version::Authority,
 };
@@ -107,9 +108,8 @@ fn update_channel(
 
     let updates = local_channel.components_to_update(upstream_channel);
 
-    let libs = ["std", "base"];
     let (libraries, executables): (Vec<_>, Vec<_>) =
-        updates.iter().partition(|c| libs.contains(&(c.name.as_ref())));
+        updates.iter().partition(|c| DEPENDENCIES.contains(&(c.name.as_ref())));
 
     for lib in libraries {
         let lib_path = toolchain_dir.join("lib").join(lib.name.as_ref()).with_extension("masp");

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -24,7 +24,7 @@ pub fn update(
 midenup install stable
 ",
             )?;
-            // NOTE: This means that there is no stable toolchain upstram.  This
+            // NOTE: This means that there is no stable toolchain upstream.  This
             // is most likely an edge-case that shouldn't happen. If it does
             // happen, it probably means there's an error in midenup's parsing.
             let upstream_stable = config

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 
-use crate::{commands, manifest::Manifest};
+use crate::{manifest::Manifest, utils};
 
 #[derive(Debug)]
 /// This struct holds contextual information about the environment in which
@@ -51,9 +51,84 @@ impl Config {
 
         Ok(config)
     }
+}
 
-    /// This ensures that the midneup directory is properly initialized.
-    pub fn ensure_midenup_home_exists(&self) -> anyhow::Result<()> {
-        commands::init(self)
+/// This functions bootstrap the `midenup` environment (create directories,
+/// default config, etc.), if not already done.
+/// A message is displayed when the directory is initialized.
+/// NOTE: If at least one element (be it a file, directory, etc) is missing,
+/// then it is considered as "uninitialized".
+pub fn ensure_midenup_home_exists(config: &Config) -> anyhow::Result<()> {
+    // Create the data directory layout.
+    //
+    // The following is a sketch of the directory tree and contents
+    //
+    // $MIDENUP_HOME
+    // |- bin/
+    // | |- miden --> $CARGO_INSTALL_DIR/midenup
+    // |- toolchains
+    // | |- stable/ --> <channel>/
+    // | |- <channel>/
+    // | | |- bin/
+    // | | |- lib/
+    // | | | |- std.masp
+    // |- config.toml
+    // |- manifest.json
+    let mut already_exists = true;
+
+    let midenhome_dir = &config.midenup_home;
+    if !midenhome_dir.exists() {
+        std::fs::create_dir_all(midenhome_dir).with_context(|| {
+            format!("failed to initialize MIDENUP_HOME directory: '{}'", midenhome_dir.display())
+        })?;
+        already_exists = false;
     }
+    let local_manifest_file = config.midenup_home.join("manifest").with_extension("json");
+    if !local_manifest_file.exists() {
+        std::fs::File::create(&local_manifest_file).with_context(|| {
+            format!(
+                "failed to create local manifest.json file in: '{}'",
+                local_manifest_file.display()
+            )
+        })?;
+        already_exists = false;
+    }
+
+    let bin_dir = config.midenup_home.join("bin");
+    if !bin_dir.exists() {
+        std::fs::create_dir_all(&bin_dir).with_context(|| {
+            format!("failed to initialize MIDENUP_HOME subdirectory: '{}'", bin_dir.display())
+        })?;
+        already_exists = false;
+    }
+
+    // Write the symlink for `miden` to $MIDENUP_HOME/bin
+    let current_exe =
+        std::env::current_exe().expect("unable to get location of current executable");
+    let miden_exe = bin_dir.join("miden");
+    if !miden_exe.exists() {
+        utils::symlink(&miden_exe, &current_exe)?;
+        already_exists = false;
+    }
+
+    let toolchains_dir = config.midenup_home.join("toolchains");
+    if !toolchains_dir.exists() {
+        std::fs::create_dir_all(&toolchains_dir).with_context(|| {
+            format!(
+                "failed to initialize MIDENUP_HOME subdirectory: '{}'",
+                toolchains_dir.display()
+            )
+        })?;
+        already_exists = false;
+    }
+
+    if !already_exists {
+        std::println!(
+            "midenup was successfully initialized in:
+{}",
+            config.midenup_home.as_path().display()
+        );
+    }
+
+    Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,8 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::Context;
 
-use crate::manifest::Manifest;
+use crate::{commands, manifest::Manifest};
 
 #[derive(Debug)]
 /// This struct holds contextual information about the environment in which

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Context;
 
-use crate::{manifest::Manifest, utils};
+use crate::manifest::Manifest;
 
 #[derive(Debug)]
 /// This struct holds contextual information about the environment in which
@@ -51,84 +51,4 @@ impl Config {
 
         Ok(config)
     }
-}
-
-/// This functions bootstrap the `midenup` environment (create directories,
-/// default config, etc.), if not already done.
-/// A message is displayed when the directory is initialized.
-/// NOTE: If at least one element (be it a file, directory, etc) is missing,
-/// then it is considered as "uninitialized".
-pub fn ensure_midenup_home_exists(config: &Config) -> anyhow::Result<()> {
-    // Create the data directory layout.
-    //
-    // The following is a sketch of the directory tree and contents
-    //
-    // $MIDENUP_HOME
-    // |- bin/
-    // | |- miden --> $CARGO_INSTALL_DIR/midenup
-    // |- toolchains
-    // | |- stable/ --> <channel>/
-    // | |- <channel>/
-    // | | |- bin/
-    // | | |- lib/
-    // | | | |- std.masp
-    // |- config.toml
-    // |- manifest.json
-    let mut already_exists = true;
-
-    let midenhome_dir = &config.midenup_home;
-    if !midenhome_dir.exists() {
-        std::fs::create_dir_all(midenhome_dir).with_context(|| {
-            format!("failed to initialize MIDENUP_HOME directory: '{}'", midenhome_dir.display())
-        })?;
-        already_exists = false;
-    }
-    let local_manifest_file = config.midenup_home.join("manifest").with_extension("json");
-    if !local_manifest_file.exists() {
-        std::fs::File::create(&local_manifest_file).with_context(|| {
-            format!(
-                "failed to create local manifest.json file in: '{}'",
-                local_manifest_file.display()
-            )
-        })?;
-        already_exists = false;
-    }
-
-    let bin_dir = config.midenup_home.join("bin");
-    if !bin_dir.exists() {
-        std::fs::create_dir_all(&bin_dir).with_context(|| {
-            format!("failed to initialize MIDENUP_HOME subdirectory: '{}'", bin_dir.display())
-        })?;
-        already_exists = false;
-    }
-
-    // Write the symlink for `miden` to $MIDENUP_HOME/bin
-    let current_exe =
-        std::env::current_exe().expect("unable to get location of current executable");
-    let miden_exe = bin_dir.join("miden");
-    if !miden_exe.exists() {
-        utils::symlink(&miden_exe, &current_exe)?;
-        already_exists = false;
-    }
-
-    let toolchains_dir = config.midenup_home.join("toolchains");
-    if !toolchains_dir.exists() {
-        std::fs::create_dir_all(&toolchains_dir).with_context(|| {
-            format!(
-                "failed to initialize MIDENUP_HOME subdirectory: '{}'",
-                toolchains_dir.display()
-            )
-        })?;
-        already_exists = false;
-    }
-
-    if !already_exists {
-        std::println!(
-            "midenup was successfully initialized in:
-{}",
-            config.midenup_home.as_path().display()
-        );
-    }
-
-    Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,13 +52,8 @@ impl Config {
         Ok(config)
     }
 
-    pub fn ensure_midenup_home_exists(&self) -> anyhow::Result<&Path> {
-        if !self.midenup_home.exists() {
-            std::fs::create_dir_all(&self.midenup_home).with_context(|| {
-                format!("failed to create MIDENUP_HOME with path: {}", self.midenup_home.display())
-            })?;
-        }
-
-        Ok(&self.midenup_home)
+    /// This ensures that the midneup directory is properly initialized.
+    pub fn ensure_midenup_home_exists(&self) -> anyhow::Result<()> {
+        commands::init(self)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -377,7 +377,7 @@ fn main() -> anyhow::Result<()> {
     match cli.behavior {
         Behavior::Miden(argv) => {
             // Make sure we know the current toolchain so we can modify the PATH appropriately
-            let toolchain = Toolchain::current()?;
+            let toolchain = Toolchain::ensure_current_is_installed(&config, &mut local_manifest)?;
 
             // Extract the target binary to execute from argv[1]
             let subcommand = {

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,7 +288,7 @@ impl Commands {
     /// Execute the requested subcommand
     fn execute(&self, config: &Config, local_manifest: &mut Manifest) -> anyhow::Result<()> {
         match &self {
-            Self::Init => commands::init(config, local_manifest),
+            Self::Init => commands::init(config),
             Self::Install { channel, .. } => {
                 let Some(channel) = config.manifest.get_channel(channel) else {
                     bail!("channel '{}' doesn't exist or is unavailable", channel);

--- a/src/main.rs
+++ b/src/main.rs
@@ -589,14 +589,12 @@ mod tests {
 
         let (mut local_manifest, config) = test_setup(&midenup_home, FILE);
 
-        let init = Commands::Init;
-        init.execute(&config, &mut local_manifest).expect("Failed to init");
-
-        let manifest = midenup_home.join("manifest").with_extension("json");
-        assert!(manifest.exists());
-
         let install = Commands::Install { channel: UserChannel::Stable };
         install.execute(&config, &mut local_manifest).expect("Failed to install stable");
+
+        // After install is executed, the local manifest should be present
+        let manifest = midenup_home.join("manifest").with_extension("json");
+        assert!(manifest.exists());
 
         let stable_dir = midenup_home.join("toolchains").join("stable");
         assert!(stable_dir.exists());
@@ -641,13 +639,11 @@ mod tests {
 
         let (mut local_manifest, config) = test_setup(&midenup_home, FILE_PRE_UPDATE);
 
-        let init = Commands::Init;
-        init.execute(&config, &mut local_manifest).expect("Failed to init");
-        let manifest = midenup_home.join("manifest").with_extension("json");
-        assert!(manifest.exists());
-
         let install = Commands::Install { channel: UserChannel::Stable };
         install.execute(&config, &mut local_manifest).expect("Failed to install stable");
+        // After install is executed, the local manifest should be present
+        let manifest = midenup_home.join("manifest").with_extension("json");
+        assert!(manifest.exists());
         let stable_dir = midenup_home.join("toolchains").join("stable");
         assert!(stable_dir.exists());
         assert!(stable_dir.is_symlink());
@@ -715,15 +711,13 @@ mod tests {
 
         let (mut local_manifest, config) = test_setup(&midenup_home, FILE_PRE_UPDATE);
 
-        let init = Commands::Init;
-        init.execute(&config, &mut local_manifest).expect("Failed to init");
-        let manifest = midenup_home.join("manifest").with_extension("json");
-        assert!(manifest.exists());
-
         let install = Commands::Install {
             channel: UserChannel::Version(semver::Version::new(0, 14, 0)),
         };
         install.execute(&config, &mut local_manifest).expect("Failed to install 0.14.0");
+        // After install is executed, the local manifest should be present
+        let manifest = midenup_home.join("manifest").with_extension("json");
+        assert!(manifest.exists());
         let version = semver::Version::new(0, 14, 0);
         let old_std = local_manifest
             .get_channel(&UserChannel::Version(version.clone()))
@@ -782,15 +776,14 @@ mod tests {
 
         let (mut local_manifest, config) = test_setup(&midenup_home, FILE_PRE_UPDATE);
 
-        let init = Commands::Init;
-        init.execute(&config, &mut local_manifest).expect("Failed to init");
-        let manifest = midenup_home.join("manifest").with_extension("json");
-        assert!(manifest.exists());
-
         let install = Commands::Install {
             channel: UserChannel::Version(semver::Version::new(0, 14, 0)),
         };
         install.execute(&config, &mut local_manifest).expect("Failed to install 0.14.0");
+        // After install is executed, the local manifest should be present
+        let manifest = midenup_home.join("manifest").with_extension("json");
+        assert!(manifest.exists());
+
         let toolchain_path = midenup_home.join("toolchains").join("0.14.0");
         assert!(toolchain_path.join("installation-successful").exists());
         assert!(toolchain_path.exists());
@@ -854,12 +847,10 @@ mod tests {
 
         let (mut local_manifest, config) = test_setup(&midenup_home, FILE_PRE_UPDATE);
 
-        let init = Commands::Init;
-        init.execute(&config, &mut local_manifest).expect("Failed to init");
-        let manifest = midenup_home.join("manifest").with_extension("json");
-        assert!(manifest.exists());
-
         let install = Commands::Install { channel: UserChannel::Stable };
         install.execute(&config, &mut local_manifest).expect("Failed to install stable");
+        // After install is executed, the local manifest should be present
+        let manifest = midenup_home.join("manifest").with_extension("json");
+        assert!(manifest.exists());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -378,7 +378,6 @@ fn main() -> anyhow::Result<()> {
         Behavior::Miden(argv) => {
             // Make sure we know the current toolchain so we can modify the PATH appropriately
             let toolchain = Toolchain::ensure_current_is_installed(&config, &mut local_manifest)?;
-
             // Extract the target binary to execute from argv[1]
             let subcommand = {
                 let subcommand = argv.get(1).ok_or(anyhow!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod version;
 
 use std::{ffi::OsString, path::PathBuf, str::FromStr};
 
-use anyhow::{anyhow, bail, Context};
+use anyhow::{Context, anyhow, bail};
 use clap::{Args, FromArgMatches, Parser, Subcommand};
 use colored::Colorize;
 use commands::INSTALLABLE_COMPONENTS;
@@ -399,7 +399,7 @@ miden help"
                         // NOTE: This could either be a [MidenCommands] or a
                         // [MidenComponents].
                         let component = argv.get(2).and_then(|c| c.to_str());
-                        let help_message = handle_help(component, &toolchain)?;
+                        let help_message = handle_help(component)?;
                         match help_message {
                             HelpMessage::Internal { help_message } => {
                                 std::println!("{help_message}");
@@ -476,7 +476,7 @@ miden help"
 }
 
 /// Wrapper function that handles help messaging dispatch
-fn handle_help(component: Option<&str>, toolchain: &Toolchain) -> anyhow::Result<HelpMessage> {
+fn handle_help(component: Option<&str>) -> anyhow::Result<HelpMessage> {
     if let Some(component) = component {
         if let Ok(component) = MidenComponents::from_str(component) {
             Ok(component.help_command())
@@ -490,11 +490,11 @@ miden help",
             )
         }
     } else {
-        Ok(HelpMessage::Internal { help_message: default_help(toolchain) })
+        Ok(HelpMessage::Internal { help_message: default_help() })
     }
 }
 
-fn default_help(current: &Toolchain) -> String {
+fn default_help() -> String {
     // Note:
     let aliases: String = [
         "account", "faucet", "new", "build", "test", "deploy", "call", "send", "simulate",
@@ -503,13 +503,8 @@ fn default_help(current: &Toolchain) -> String {
     .map(|alias| format!("  {}\n", alias.bold()))
     .collect();
 
-    let available_components: String = current
-        .components
+    let available_components: String = INSTALLABLE_COMPONENTS
         .iter()
-        .filter(|c| {
-            let c = c.as_str();
-            INSTALLABLE_COMPONENTS.contains(&c)
-        })
         .map(|c| {
             let component_name = c.replace("miden-", "");
             format!("  {}\n", component_name.bold())

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod version;
 
 use std::{ffi::OsString, path::PathBuf, str::FromStr};
 
-use anyhow::{Context, anyhow, bail};
+use anyhow::{anyhow, bail, Context};
 use clap::{Args, FromArgMatches, Parser, Subcommand};
 use colored::Colorize;
 use commands::INSTALLABLE_COMPONENTS;

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,7 +288,7 @@ impl Commands {
     /// Execute the requested subcommand
     fn execute(&self, config: &Config, local_manifest: &mut Manifest) -> anyhow::Result<()> {
         match &self {
-            Self::Init => commands::init(config),
+            Self::Init => commands::init(config, local_manifest),
             Self::Install { channel, .. } => {
                 let Some(channel) = config.manifest.get_channel(channel) else {
                     bail!("channel '{}' doesn't exist or is unavailable", channel);

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -98,7 +98,7 @@ impl Toolchain {
 
         let channel_dir = config.midenup_home.join("toolchains").join(format!("{}", channel.name));
         if !channel_dir.exists() {
-            println!("Found current toolchain to be {}. Now installing it.", channel.name);
+            println!("Found current toolchain to be {desired_channel}. Now installing it.",);
             commands::install(config, channel, local_manifest)?
         }
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -1,7 +1,9 @@
-use anyhow::Context;
+use std::path::PathBuf;
+
+use anyhow::{Context, bail};
 use serde::{Deserialize, Serialize};
 
-use crate::channel::UserChannel;
+use crate::{Config, channel::UserChannel, commands, manifest::Manifest};
 
 /// Represents a `miden-toolchain.toml` file. These file contains the desired
 /// toolchain to be used.
@@ -47,10 +49,16 @@ impl Toolchain {
     pub fn new(channel: UserChannel, components: Vec<String>) -> Self {
         Toolchain { channel, components }
     }
-    pub fn current() -> anyhow::Result<Self> {
+
+    fn toolchain_file() -> anyhow::Result<PathBuf> {
         // Check for a `miden-toolchain.toml` file in $CWD
         let cwd = std::env::current_dir().context("unable to read current working directory")?;
         let toolchain_file = cwd.join("miden-toolchain").with_extension("toml");
+        Ok(toolchain_file)
+    }
+
+    pub fn current() -> anyhow::Result<Self> {
+        let toolchain_file = Self::toolchain_file()?;
         if !toolchain_file.exists() {
             // The default toolchain is stable
             //
@@ -67,10 +75,34 @@ impl Toolchain {
         let toolchain_file: ToolchainFile =
             toml::from_str(&toolchain_file_contents).context("invalid toolchain file")?;
 
-        let present_toolchain = toolchain_file.inner_toolchain();
+        let current_toolchain = toolchain_file.inner_toolchain();
 
-        Ok(present_toolchain)
+        Ok(current_toolchain)
     }
 
+    pub fn ensure_current_is_installed(
+        config: &Config,
+        local_manifest: &mut Manifest,
+    ) -> anyhow::Result<Self> {
+        let current_toolchain = Self::current()?;
+        let desired_channel = &current_toolchain.channel;
+
+        let Some(channel) = config.manifest.get_channel(desired_channel) else {
+            let toolchain_file = Self::toolchain_file()?;
+            bail!(
+                "Channel '{}' is set in {}, however the channel doesn't exist or is unavailable",
+                desired_channel,
+                toolchain_file.display()
+            );
+        };
+
+        let channel_dir = config.midenup_home.join("toolchains").join(format!("{}", channel.name));
+        if !channel_dir.exists() {
+            std::println!("Found current toolchain to be {}. Now installing it.", channel.name);
+            commands::install(config, channel, local_manifest)?
+        }
+
+        // Now installed
+        Ok(current_toolchain)
     }
 }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -98,7 +98,7 @@ impl Toolchain {
 
         let channel_dir = config.midenup_home.join("toolchains").join(format!("{}", channel.name));
         if !channel_dir.exists() {
-            std::println!("Found current toolchain to be {}. Now installing it.", channel.name);
+            println!("Found current toolchain to be {}. Now installing it.", channel.name);
             commands::install(config, channel, local_manifest)?
         }
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -67,6 +67,10 @@ impl Toolchain {
         let toolchain_file: ToolchainFile =
             toml::from_str(&toolchain_file_contents).context("invalid toolchain file")?;
 
-        Ok(toolchain_file.inner_toolchain())
+        let present_toolchain = toolchain_file.inner_toolchain();
+
+        Ok(present_toolchain)
+    }
+
     }
 }


### PR DESCRIPTION
Closes #50

Separates the `commands::init` function into two separate parts.
The main bulk of functionality was moved to the `config::ensure_midenup_home_exists` function. This was done to homogenize guarantee that the midenup directory always initialized consistently.

Now, the `commands::init` function also installs stable if it is not present in the midenup directoy. This was the original intended behavior that was missing.