### PR TITLE
feat: install toolchains from `miden-toolchain.toml` if missing

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -69,7 +69,7 @@ pub fn init(config: &Config) -> anyhow::Result<()> {
         bail!("midenup has already been initialized");
     }
 
-    std::println!(
+    println!(
         "midenup was successfully initialized in:
 {}",
         config.midenup_home.as_path().display()

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -3,9 +3,9 @@ use std::io::Write;
 use anyhow::Context;
 
 use crate::{
-    Config,
     channel::UserChannel,
     toolchain::{Toolchain, ToolchainFile},
+    Config,
 };
 
 const TOOLCHAIN_FILE_NAME: &str = "miden-toolchain.toml";
@@ -20,7 +20,17 @@ pub fn set(config: &Config, channel: &UserChannel) -> anyhow::Result<()> {
         .join(channel.to_string())
         .join("installation-successful");
 
-    let components = std::fs::read_to_string(current_components_list).unwrap();
+    let components = {
+        match std::fs::read_to_string(current_components_list) {
+            Ok(componets) => componets,
+            Err(_) => {
+                std::println!(
+                    "WARNING: Non present toolchain was set. Component list will be left empty"
+                );
+                String::default()
+            },
+        }
+    };
     let components: Vec<String> = components.lines().map(String::from).collect();
 
     let installed_toolchain = Toolchain::new(channel.clone(), components);

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -42,6 +42,8 @@ pub fn set(config: &Config, channel: &UserChannel) -> anyhow::Result<()> {
     let toolchain_file_contents = toml::to_string_pretty(&installed_toolchain)
         .context("Failed to generate miden-toolchain.toml")?;
 
-    toolchain_file.write_all(&toolchain_file_contents.into_bytes()).unwrap();
+    toolchain_file
+        .write_all(&toolchain_file_contents.into_bytes())
+        .context("Failed to write miden-toolchain.toml")?;
     Ok(())
 }

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -3,9 +3,9 @@ use std::io::Write;
 use anyhow::Context;
 
 use crate::{
+    Config,
     channel::UserChannel,
     toolchain::{Toolchain, ToolchainFile},
-    Config,
 };
 
 const TOOLCHAIN_FILE_NAME: &str = "miden-toolchain.toml";

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -24,7 +24,7 @@ pub fn set(config: &Config, channel: &UserChannel) -> anyhow::Result<()> {
         match std::fs::read_to_string(current_components_list) {
             Ok(components) => components,
             Err(_) => {
-                std::println!(
+                println!(
                     "WARNING: Non present toolchain was set. Component list will be left empty"
                 );
                 String::default()

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -22,7 +22,7 @@ pub fn set(config: &Config, channel: &UserChannel) -> anyhow::Result<()> {
 
     let components = {
         match std::fs::read_to_string(current_components_list) {
-            Ok(componets) => componets,
+            Ok(components) => components,
             Err(_) => {
                 std::println!(
                     "WARNING: Non present toolchain was set. Component list will be left empty"

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -35,7 +35,7 @@ midenup install stable
             if upstream_stable.name > local_stable.name {
                 commands::install(config, upstream_stable, local_manifest)?
             } else {
-                std::println!("Nothing to update, you are all up to date");
+                println!("Nothing to update, you are all up to date");
             }
         },
         Some(UserChannel::Version(version)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,7 +206,7 @@ Help:
                         "miden".bold(),
                         available_components
                     );
-                    std::println!("{help_message}");
+                    println!("{help_message}");
                     return Ok(());
                 },
                 "account" => (String::from("miden-client"), vec![String::from("account")]),

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,14 +168,10 @@ fn main() -> anyhow::Result<()> {
     match cli.behavior {
         Behavior::Miden(argv) => {
             // Extract the target binary to execute from argv[1]
-            let subcommand = argv
-                .get(1)
-                .ok_or(
-                    anyhow!(
-                        "ERROR: No arguments were passed to `miden`. To get a list of available commands, run:
+            let subcommand = argv.get(1).ok_or(anyhow!(
+                "No arguments were passed to `miden`. To get a list of available commands, run:
 miden help"
-                    )
-                )?;
+            ))?;
             let subcommand = subcommand.to_str().expect("Invalid command name: {subcommand}");
             // Make sure we know the current toolchain so we can modify the PATH appropriately
             let toolchain = Toolchain::current()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,7 @@ miden help"
             ))?;
             let subcommand = subcommand.to_str().expect("Invalid command name: {subcommand}");
             // Make sure we know the current toolchain so we can modify the PATH appropriately
-            let toolchain = Toolchain::current()?;
+            let toolchain = Toolchain::ensure_current_is_installed(&config, &mut local_manifest)?;
 
             let (target_exe, prefix_args) = match subcommand {
                 "help" => {

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -66,6 +66,10 @@ impl Toolchain {
         let toolchain_file: ToolchainFile =
             toml::from_str(&toolchain_file_contents).context("invalid toolchain file")?;
 
-        Ok(toolchain_file.inner_toolchain())
+        let present_toolchain = toolchain_file.inner_toolchain();
+
+        Ok(present_toolchain)
+    }
+
     }
 }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -97,7 +97,7 @@ impl Toolchain {
 
         let channel_dir = config.midenup_home.join("toolchains").join(format!("{}", channel.name));
         if !channel_dir.exists() {
-            std::println!("Found current toolchain to be {}. Now installing it.", channel.name);
+            println!("Found current toolchain to be {}. Now installing it.", channel.name);
             commands::install(config, channel, local_manifest)?
         }
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -1,7 +1,9 @@
-use anyhow::Context;
+use std::path::PathBuf;
+
+use anyhow::{Context, bail};
 use serde::{Deserialize, Serialize};
 
-use crate::channel::UserChannel;
+use crate::{Config, channel::UserChannel, commands, manifest::Manifest};
 
 /// Represents a `miden-toolchain.toml` file
 #[derive(Serialize, Deserialize, Debug)]
@@ -46,10 +48,16 @@ impl Toolchain {
     pub fn new(channel: UserChannel, components: Vec<String>) -> Self {
         Toolchain { channel, components }
     }
-    pub fn current() -> anyhow::Result<Self> {
+
+    fn toolchain_file() -> anyhow::Result<PathBuf> {
         // Check for a `miden-toolchain.toml` file in $CWD
         let cwd = std::env::current_dir().context("unable to read current working directory")?;
         let toolchain_file = cwd.join("miden-toolchain").with_extension("toml");
+        Ok(toolchain_file)
+    }
+
+    pub fn current() -> anyhow::Result<Self> {
+        let toolchain_file = Self::toolchain_file()?;
         if !toolchain_file.exists() {
             // The default toolchain is stable
             //
@@ -66,10 +74,34 @@ impl Toolchain {
         let toolchain_file: ToolchainFile =
             toml::from_str(&toolchain_file_contents).context("invalid toolchain file")?;
 
-        let present_toolchain = toolchain_file.inner_toolchain();
+        let current_toolchain = toolchain_file.inner_toolchain();
 
-        Ok(present_toolchain)
+        Ok(current_toolchain)
     }
 
+    pub fn ensure_current_is_installed(
+        config: &Config,
+        local_manifest: &mut Manifest,
+    ) -> anyhow::Result<Self> {
+        let current_toolchain = Self::current()?;
+        let desired_channel = &current_toolchain.channel;
+
+        let Some(channel) = config.manifest.get_channel(desired_channel) else {
+            let toolchain_file = Self::toolchain_file()?;
+            bail!(
+                "Channel '{}' is set in {}, however the channel doesn't exist or is unavailable",
+                desired_channel,
+                toolchain_file.display()
+            );
+        };
+
+        let channel_dir = config.midenup_home.join("toolchains").join(format!("{}", channel.name));
+        if !channel_dir.exists() {
+            std::println!("Found current toolchain to be {}. Now installing it.", channel.name);
+            commands::install(config, channel, local_manifest)?
+        }
+
+        // Now installed
+        Ok(current_toolchain)
     }
 }


### PR DESCRIPTION
Closes #24 

If the `miden` command detects a `miden-toolchain.toml` file and it specifies a toolchain that has not been installed; then install the missing toolchain.