### PR TITLE
fix: replace the call to `miden --version` with a call to `miden help`

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -78,7 +78,7 @@ pub fn setup_midenup(config: &Config) -> anyhow::Result<bool> {
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .stdin(std::process::Stdio::null())
-        .arg("--version")
+        .arg("help")
         .output()
         .is_ok();
 


### PR DESCRIPTION
Closes #66 

If `miden <COMPONENT>` gets run  and the `miden` executable *IS* present in the PATH, `miden` gets stuck. This happens in the call to `std::process::Command (...) `miden --version`. `miden` does not recognize `--version` as a flag, so it got replaced with `help`.

With this patch, `miden` no longer gets stuck. 