### PR TITLE
feat: when uninstalling, inform when the toolchain is not installed

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -435,13 +435,7 @@ impl core::str::FromStr for UserChannel {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        fs::File,
-        io::{BufReader, Write},
-        path::Path,
-    };
 
-    use super::InstalledFile;
     use crate::{
         channel::{Channel, Component},
         version::{Authority, GitTarget},

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,12 +120,7 @@ impl Commands {
                 };
                 commands::install(config, channel, local_manifest)
             },
-            Self::Uninstall { channel, .. } => {
-                let Some(channel) = config.manifest.get_channel(channel) else {
-                    bail!("channel '{}' doesn't exist or is unavailable", channel);
-                };
-                commands::uninstall(config, channel, local_manifest)
-            },
+            Self::Uninstall { channel, .. } => commands::uninstall(config, channel, local_manifest),
             Self::Update { channel } => commands::update(config, channel.as_ref(), local_manifest),
             Self::Show(cmd) => cmd.execute(config, local_manifest),
             Self::Set { channel } => commands::set(config, channel),


### PR DESCRIPTION
Closes #71

A different error message is displayed if a user passes in a non-installed toolchain to `midenup uninstall`.