### PR TITLE
feat: aliases in manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,8 +315,6 @@ dependencies = [
  "serde",
  "serde-untagged",
  "serde_json",
- "strum",
- "strum_macros",
  "tempdir",
  "thiserror",
  "toml",
@@ -540,24 +538,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,6 @@ upon = { version = "0.9.0", default-features = false, features = [
     "unicode",
 ] }
 colored = "3.0.0"
-strum_macros = "0.27.2"
-strum = "0.27.2"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -29,7 +29,15 @@
           "repository_url": "https://github.com/0xMiden/miden-client.git",
           "crate_name": "miden-client-cli",
           "revision": "83df2aa115b2617e211d1d929a1189ffabbd137b",
-          "installed_executable": "miden-client"
+          "installed_executable": "miden-client",
+          "aliases": {
+              "account": [{"resolve": "client"}, {"verbatim": "new-account"}],
+              "faucet": [{"resolve": "client"}, {"verbatim": "mint"}],
+              "deploy": [{"resolve": "client"}, {"verbatim": "new-wallet"}, {"verbatim": "--deploy"}],
+              "call": [{"resolve": "client"}, {"verbatim": "call"}, {"verbatim": "--show"}],
+              "send": [{"resolve": "client"}, {"verbatim": "send"}],
+              "simulate": [{"resolve": "client"}, {"verbatim": "exec"}]
+            }
         },
         {
           "name": "midenc",
@@ -39,7 +47,11 @@
         {
           "name": "cargo-miden",
           "version": "0.1.0",
-          "rustup_channel": "nightly-2025-03-20"
+          "rustup_channel": "nightly-2025-03-20",
+          "aliases": {
+              "new": [{"verbatim": "cargo"}, {"verbatim": "miden"}, {"verbatim": "new"}],
+              "build": [{"verbatim": "cargo"}, {"verbatim": "miden"}, {"verbatim": "build"}]
+            }
         }
       ]
     },
@@ -69,7 +81,15 @@
           "name": "client",
           "package": "miden-client-cli",
           "version": "0.10.0",
-          "installed_executable": "miden-client"
+          "installed_executable": "miden-client",
+          "aliases": {
+              "account": [{"resolve": "client"}, {"verbatim": "new-account"}],
+              "faucet": [{"resolve": "client"}, {"verbatim": "mint"}],
+              "deploy": [{"resolve": "client"}, {"verbatim": "new-wallet"}, {"verbatim": "--deploy"}],
+              "call": [{"resolve": "client"}, {"verbatim": "call"}, {"verbatim": "--show"}],
+              "send": [{"resolve": "client"}, {"verbatim": "send"}],
+              "simulate": [{"resolve": "client"}, {"verbatim": "exec"}]
+            }
         },
         {
           "name": "midenc",
@@ -79,7 +99,11 @@
         {
           "name": "cargo-miden",
           "version": "0.1.0",
-          "rustup_channel": "nightly-2025-03-20"
+          "rustup_channel": "nightly-2025-03-20",
+          "aliases": {
+              "new": [{"verbatim": "cargo"}, {"verbatim": "miden"}, {"verbatim": "new"}],
+              "build": [{"verbatim": "cargo"}, {"verbatim": "miden"}, {"verbatim": "build"}]
+            }
         }
       ]
     }

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -80,7 +80,7 @@
         {
           "name": "client",
           "package": "miden-client-cli",
-          "version": "0.10.0",
+          "version": "0.10.2",
           "installed_executable": "miden-client",
           "aliases": {
               "account": [{"resolve": "client"}, {"verbatim": "new-account"}],

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -6,13 +6,12 @@ use std::{
     path::PathBuf,
 };
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    utils,
+    Config, utils,
     version::{Authority, GitTarget},
-    Config,
 };
 
 /// Represents a specific release channel for a toolchain.
@@ -502,7 +501,7 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::{
-        channel::{Alias, AliasResolution, Channel, CliArgument, Component},
+        channel::{Channel, Component},
         version::{Authority, GitTarget},
     };
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -261,11 +261,11 @@ pub enum CliArgument {
 }
 
 impl CliArgument {
-    pub fn get_executable(&self, channel: &Channel) -> anyhow::Result<String> {
+    pub fn resolve_command(&self, channel: &Channel) -> anyhow::Result<String> {
         match self {
             CliArgument::Verbatim { name } => Ok(name.to_string()),
             CliArgument::Resolve { name } => {
-                let component = channel.get_component(&name).with_context(|| {
+                let component = channel.get_component(name).with_context(|| {
                     format!(
                         "Component named {} is not present in toolchain version {}",
                         name, channel.name

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io::Write};
+use std::io::Write;
 
 use anyhow::Context;
 
@@ -324,19 +324,21 @@ fn main() {
     let symlinks = channel
         .components
         .iter()
-        .fold(HashMap::new(), |mut acc, component| {
+        .flat_map(|component| {
+            let mut executables = Vec::new();
+
             let aliases = component.aliases.keys();
             let exe_name = component.get_installed_file();
             if let InstalledFile::Executable { ref binary_name } = exe_name {
                 let miden_prefix = format!("miden {}", component.name);
                 for alias in aliases {
-                    acc.insert(alias.clone(), miden_prefix.clone());
+                    executables.push((alias.clone(), miden_prefix.clone()));
                 }
-                acc.insert(miden_prefix, binary_name.clone());
+                executables.push((miden_prefix, binary_name.clone()));
             }
-            acc
+
+            executables
         })
-        .iter()
         .map(|(alias, binary)| {
             upon::value! {
                 alias: alias,

--- a/src/miden_wrapper.rs
+++ b/src/miden_wrapper.rs
@@ -189,15 +189,16 @@ miden help"
                     (binary, vec![])
                 },
                 Err(_) => {
-                    let components = toolchain_environment.get_components_display();
                     let aliases = toolchain_environment.get_aliases_display();
+                    let components = toolchain_environment.get_components_display();
                     bail!(
                         "Failed to resolve {}: Neither known alias or component.
 
-        These are the known aliases:
-        {components}
-        And these are the known components:
-        {aliases}
+These are the known aliases:
+{aliases}
+And these are the known components:
+{components}
+
         ",
                         resolve.clone(),
                     );
@@ -288,16 +289,16 @@ fn toolchain_help(toolchain_environment: &ToolchainEnvironment) -> String {
 
 fn default_help() -> String {
     let asterisk = "*".bold();
+    let help = "Help:".bold().underline();
     format!(
         "The Miden toolchain porcelain
 
-{}
+{help}
   help                   Print this help message
-  help toolchain         Print help about the current toolchain {asterisk}
-  help <COMPONENT>       Print <COMPONENTS>'s help message {asterisk}
+  help toolchain         Print help about the currently available aliases and components {asterisk}
+  help <COMPONENT>       Print a specific <COMPONENTS>'s help message {asterisk}
 
 {asterisk}: These commands will install the currently present toolchain if not installed.
 ",
-        "Help:".bold().underline(),
     )
 }

--- a/src/miden_wrapper.rs
+++ b/src/miden_wrapper.rs
@@ -147,7 +147,7 @@ miden help"
         MidenSubcommand::Help(HelpMessage::Toolchain) => {
             let help = toolchain_help(&toolchain_environment);
 
-            std::println!("{help}");
+            println!("{help}");
 
             return Ok(());
         },

--- a/src/miden_wrapper.rs
+++ b/src/miden_wrapper.rs
@@ -1,8 +1,7 @@
 use std::{collections::HashMap, ffi::OsString, string::ToString};
 
-use anyhow::{Context, anyhow, bail};
+use anyhow::{anyhow, bail, Context};
 use colored::Colorize;
-use strum::IntoEnumIterator;
 
 pub use crate::config::Config;
 use crate::{

--- a/src/miden_wrapper.rs
+++ b/src/miden_wrapper.rs
@@ -5,7 +5,7 @@ use colored::Colorize;
 
 pub use crate::config::Config;
 use crate::{
-    channel::{Alias, AliasResolution, Channel, Component, InstalledFile},
+    channel::{Alias, CLICommand, Channel, Component, InstalledFile},
     manifest::Manifest,
     toolchain::Toolchain,
 };
@@ -35,7 +35,7 @@ enum MidenArgument<'a> {
     /// The passed argument was an Alias stored in the local [[Manifest]]. [[AliasResolution]]
     /// represents the list of commands that need to be executed. NOTE: Some of these might need
     /// to get resolved.
-    Alias(AliasResolution),
+    Alias(CLICommand),
     /// The argument was the name of a component stored in the [[Manifest]].
     Component(&'a Component),
 }
@@ -44,7 +44,7 @@ enum EnvironmentError {
     UnkownArgument,
 }
 struct ToolchainEnvironment {
-    aliases: HashMap<Alias, AliasResolution>,
+    aliases: HashMap<Alias, CLICommand>,
     components: Vec<Component>,
 }
 impl ToolchainEnvironment {


### PR DESCRIPTION
Close https://github.com/0xMiden/midenup/issues/79 (Cherry picked from https://github.com/0xMiden/midenup/pull/54)

This PR removes the hardcoded aliases from the `midenup` executables and moves them to the Manifest. A new value  was added to the `Component` struct called `aliases` which represents all the aliases that are associated with that component. These aliases are in the form of a map, that goes from the name of the alias to the associated list of commands.

Additionally, now the toolchain's `bin/` holds a series of symlinks. 
Firstly, for each known component, a symlink of the form `miden <component name>` is created. Like so:
```
midenup
├── bin
│   └── miden -> /Users/fabri/Repositories/midenup/miden
├── manifest.json
└── toolchains
    └── 0.15.0
        ├── bin
        (...)
        │   ├── cargo-miden
        │   ├── miden
        │   ├── miden cargo-miden -> /Users/fabri/Library/Application Support/midenup/toolchains/0.15.0/bin/cargo-miden
        │   ├── miden client -> /Users/fabri/Library/Application Support/midenup/toolchains/0.15.0/bin/miden-client
        │   ├── miden midenc -> /Users/fabri/Library/Application Support/midenup/toolchains/0.15.0/bin/midenc
        │   ├── miden vm -> /Users/fabri/Library/Application Support/midenup/toolchains/0.15.0/bin/miden
        │   ├── miden-client
        │   ├── midenc
        (...)
```
This is done to "trick" clap into providing `midenup` compatible help messages. Now, when `miden client` is run, we execute the `miden client` symlink, instead of the `miden-client` executable itself. This produces the following output. 
```
CLI actions

Usage: miden client [OPTIONS] <COMMAND>

Commands:
(...)
```
Instead of the usual:
```
CLI actions

Usage: miden-client [OPTIONS] <COMMAND>

Commands:
(...)
```

Additionally, a symlink is created for each known alias (simulate, account, faucet, etc), like mentioned in this comment (https://github.com/0xMiden/midenup/pull/43#issuecomment-3124551070). These point to the symlink which points to the corresponding binary, like so:
```
midenup
├── bin
│   └── miden -> /Users/fabri/Repositories/midenup/miden
├── manifest.json
└── toolchains
    └── 0.15.0
        ├── bin
        │   ├── account -> /Users/fabri/Library/Application Support/midenup/toolchains/0.15.0/bin/miden client
        │   ├── build -> /Users/fabri/Library/Application Support/midenup/toolchains/0.15.0/bin/miden cargo-miden
        │   ├── call -> /Users/fabri/Library/Application Support/midenup/toolchains/0.15.0/bin/miden client
        │   ├── cargo-miden
        │   ├── deploy -> /Users/fabri/Library/Application Support/midenup/toolchains/0.15.0/bin/miden client
        │   ├── miden
        │   ├── miden cargo-miden -> /Users/fabri/Library/Application Support/midenup/toolchains/0.15.0/bin/cargo-miden
        │   ├── miden client -> /Users/fabri/Library/Application Support/midenup/toolchains/0.15.0/bin/miden-client
        │   ├── miden midenc -> /Users/fabri/Library/Application Support/midenup/toolchains/0.15.0/bin/midenc
        │   ├── miden vm -> /Users/fabri/Library/Application Support/midenup/toolchains/0.15.0/bin/miden
        │   ├── miden-client
        │   ├── midenc
        │   ├── send -> /Users/fabri/Library/Application Support/midenup/toolchains/0.15.0/bin/miden client
        │   └── simulate -> /Users/fabri/Library/Application Support/midenup/toolchains/0.15.0/bin/miden client
```

However, these aliased symlinks are *not* passed to `std::Command` as is. This is because, when used, clap uses the alias's name to display help messages:
```
$ miden account
error: the following required arguments were not provided:
  --account-type <ACCOUNT_TYPE>

Usage: account new-account --account-type <ACCOUNT_TYPE>
```
The main problem being that `account new-account` is not a valid command. 

So, we resolve the alias and use the component's executable instead (i.e `miden account` executes `miden client new-account`). With this, a valid help message is displayed:

```
error: the following required arguments were not provided:
  --account-type <ACCOUNT_TYPE>

Usage: miden client new-account --account-type <ACCOUNT_TYPE>
```
