### PR TITLE
fix: update client to latest version

### DIFF
--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -68,7 +68,7 @@
         {
           "name": "client",
           "package": "miden-client-cli",
-          "version": "0.10.0",
+          "version": "0.10.2",
           "installed_executable": "miden-client"
         },
         {


### PR DESCRIPTION
Closes #79 

Ci is failing due to a compilation error when compiling the client. This error has been fixed in the latest release of the client. 