### PR TITLE
feat: pass`-L` flag to compiler

### DIFF
--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -31,7 +31,7 @@
           "revision": "83df2aa115b2617e211d1d929a1189ffabbd137b",
           "installed_executable": "miden-client",
           "aliases": {
-              "account": ["executable", "new-account"]
+              "account": ["executable", "new-account"],
               "faucet": ["executable", "mint"],
               "deploy": ["executable", "new-wallet", "--deploy"],
               "call": ["executable", "call", "--show"],
@@ -42,7 +42,8 @@
         {
           "name": "midenc",
           "version": "0.1.0",
-          "rustup_channel": "nightly-2025-03-20"
+          "rustup_channel": "nightly-2025-03-20",
+          "call_format": ["executable", "compile", "-L", "lib_path"]
         },
         {
           "name": "cargo-miden",
@@ -50,7 +51,7 @@
           "rustup_channel": "nightly-2025-03-20",
           "aliases": {
               "new": ["cargo", "miden", "new"],
-              "build": ["cargo", "miden", "build"],
+              "build": ["cargo", "miden", "build"]
           }
         }
       ]
@@ -83,7 +84,7 @@
           "version": "0.10.2",
           "installed_executable": "miden-client",
           "aliases": {
-              "account": ["executable", "new-account"]
+              "account": ["executable", "new-account"],
               "faucet": ["executable", "mint"],
               "deploy": ["executable", "new-wallet", "--deploy"],
               "call": ["executable", "call", "--show"],
@@ -94,7 +95,8 @@
         {
           "name": "midenc",
           "version": "0.1.0",
-          "rustup_channel": "nightly-2025-03-20"
+          "rustup_channel": "nightly-2025-03-20",
+          "call_format": ["executable", "compile", "-L", "lib_path"]
         },
         {
           "name": "cargo-miden",
@@ -102,7 +104,7 @@
           "rustup_channel": "nightly-2025-03-20",
           "aliases": {
               "new": ["cargo", "miden", "new"],
-              "build": ["cargo", "miden", "build"],
+              "build": ["cargo", "miden", "build"]
           }
         }
       ]

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -31,12 +31,12 @@
           "revision": "83df2aa115b2617e211d1d929a1189ffabbd137b",
           "installed_executable": "miden-client",
           "aliases": {
-              "account": [{"resolve": "client"}, {"verbatim": "new-account"}],
-              "faucet": [{"resolve": "client"}, {"verbatim": "mint"}],
-              "deploy": [{"resolve": "client"}, {"verbatim": "new-wallet"}, {"verbatim": "--deploy"}],
-              "call": [{"resolve": "client"}, {"verbatim": "call"}, {"verbatim": "--show"}],
-              "send": [{"resolve": "client"}, {"verbatim": "send"}],
-              "simulate": [{"resolve": "client"}, {"verbatim": "exec"}]
+              "account": [{"resolve": "executable"}, {"verbatim": "new-account"}],
+              "faucet": [{"resolve": "executable"}, {"verbatim": "mint"}],
+              "deploy": [{"resolve": "executable"}, {"verbatim": "new-wallet"}, {"verbatim": "--deploy"}],
+              "call": [{"resolve": "executable"}, {"verbatim": "call"}, {"verbatim": "--show"}],
+              "send": [{"resolve": "executable"}, {"verbatim": "send"}],
+              "simulate": [{"resolve": "executable"}, {"verbatim": "exec"}]
             }
         },
         {
@@ -83,12 +83,12 @@
           "version": "0.10.2",
           "installed_executable": "miden-client",
           "aliases": {
-              "account": [{"resolve": "client"}, {"verbatim": "new-account"}],
-              "faucet": [{"resolve": "client"}, {"verbatim": "mint"}],
-              "deploy": [{"resolve": "client"}, {"verbatim": "new-wallet"}, {"verbatim": "--deploy"}],
-              "call": [{"resolve": "client"}, {"verbatim": "call"}, {"verbatim": "--show"}],
-              "send": [{"resolve": "client"}, {"verbatim": "send"}],
-              "simulate": [{"resolve": "client"}, {"verbatim": "exec"}]
+              "account": [{"resolve": "executable"}, {"verbatim": "new-account"}],
+              "faucet": [{"resolve": "executable"}, {"verbatim": "mint"}],
+              "deploy": [{"resolve": "executable"}, {"verbatim": "new-wallet"}, {"verbatim": "--deploy"}],
+              "call": [{"resolve": "executable"}, {"verbatim": "call"}, {"verbatim": "--show"}],
+              "send": [{"resolve": "executable"}, {"verbatim": "send"}],
+              "simulate": [{"resolve": "executable"}, {"verbatim": "exec"}]
             }
         },
         {

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -31,13 +31,13 @@
           "revision": "83df2aa115b2617e211d1d929a1189ffabbd137b",
           "installed_executable": "miden-client",
           "aliases": {
-              "account": [{"resolve": "executable"}, {"verbatim": "new-account"}],
-              "faucet": [{"resolve": "executable"}, {"verbatim": "mint"}],
-              "deploy": [{"resolve": "executable"}, {"verbatim": "new-wallet"}, {"verbatim": "--deploy"}],
-              "call": [{"resolve": "executable"}, {"verbatim": "call"}, {"verbatim": "--show"}],
-              "send": [{"resolve": "executable"}, {"verbatim": "send"}],
-              "simulate": [{"resolve": "executable"}, {"verbatim": "exec"}]
-            }
+              "account": ["executable", "new-account"]
+              "faucet": ["executable", "mint"],
+              "deploy": ["executable", "new-wallet", "--deploy"],
+              "call": ["executable", "call", "--show"],
+              "send": ["executable", "send"],
+              "simulate": ["executable", "exec"]
+           }
         },
         {
           "name": "midenc",
@@ -49,9 +49,9 @@
           "version": "0.1.0",
           "rustup_channel": "nightly-2025-03-20",
           "aliases": {
-              "new": [{"verbatim": "cargo"}, {"verbatim": "miden"}, {"verbatim": "new"}],
-              "build": [{"verbatim": "cargo"}, {"verbatim": "miden"}, {"verbatim": "build"}]
-            }
+              "new": ["cargo", "miden", "new"],
+              "build": ["cargo", "miden", "build"],
+          }
         }
       ]
     },
@@ -83,13 +83,13 @@
           "version": "0.10.2",
           "installed_executable": "miden-client",
           "aliases": {
-              "account": [{"resolve": "executable"}, {"verbatim": "new-account"}],
-              "faucet": [{"resolve": "executable"}, {"verbatim": "mint"}],
-              "deploy": [{"resolve": "executable"}, {"verbatim": "new-wallet"}, {"verbatim": "--deploy"}],
-              "call": [{"resolve": "executable"}, {"verbatim": "call"}, {"verbatim": "--show"}],
-              "send": [{"resolve": "executable"}, {"verbatim": "send"}],
-              "simulate": [{"resolve": "executable"}, {"verbatim": "exec"}]
-            }
+              "account": ["executable", "new-account"]
+              "faucet": ["executable", "mint"],
+              "deploy": ["executable", "new-wallet", "--deploy"],
+              "call": ["executable", "call", "--show"],
+              "send": ["executable", "send"],
+              "simulate": ["executable", "exec"]
+          }
         },
         {
           "name": "midenc",
@@ -101,9 +101,9 @@
           "version": "0.1.0",
           "rustup_channel": "nightly-2025-03-20",
           "aliases": {
-              "new": [{"verbatim": "cargo"}, {"verbatim": "miden"}, {"verbatim": "new"}],
-              "build": [{"verbatim": "cargo"}, {"verbatim": "miden"}, {"verbatim": "build"}]
-            }
+              "new": ["cargo", "miden", "new"],
+              "build": ["cargo", "miden", "build"],
+          }
         }
       ]
     }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -256,15 +256,6 @@ pub enum CliCommand {
     Verbatim(String),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum Resolvable {
-    #[serde(untagged)]
-    Executable { executable: String },
-    #[serde(untagged)]
-    LibPath { libpath: String },
-}
-
 impl CliCommand {
     pub fn resolve_command(
         &self,
@@ -468,7 +459,7 @@ impl Component {
         }
     }
 
-    /// Returns the Srting representation under which midenup calls a component.
+    /// Returns the String representation under which midenup calls a component.
     pub fn get_cli_display(&self) -> String {
         format!("miden {}", self.name)
     }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -273,7 +273,7 @@ impl CliCommand {
                     )
                 })?;
 
-                Ok(format!("miden {}", component.name))
+                Ok(component.get_cli_display())
             },
         }
     }
@@ -444,6 +444,11 @@ impl Component {
         } else {
             InstalledFile::Executable { binary_name: self.name.to_string() }
         }
+    }
+
+    /// Returns the Srting representation under which midenup calls a component.
+    pub fn get_cli_display(&self) -> String {
+        format!("miden {}", self.name)
     }
 }
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -246,7 +246,10 @@ impl Display for InstalledFile {
 /// line. These are used to resolve an [[Alias]] to its associated command.
 /// NOTE: In the manifest
 pub enum CliCommand {
+    /// Resolve the command to a [[Component]]'s corresponding executable.
     Executable,
+    /// Resolve the command to a [[Toolchain]]'s library path (<toolchain>/lib)
+    #[serde(rename = "lib_path")]
     LibPath,
     /// An argument that is passed verbatim, as is.
     #[serde(untagged)]
@@ -537,7 +540,7 @@ mod tests {
     use std::collections::HashMap;
 
     use crate::{
-        channel::{Channel, CliCommand, Component},
+        channel::{Channel, Component},
         version::{Authority, GitTarget},
     };
 
@@ -549,17 +552,6 @@ mod tests {
     /// - a so called "removed-component" needs to be deleted
     /// - a so called "new-component" needs to be added
     fn check_components_to_update() {
-        let alias = vec![
-            CliCommand::Verbatim { name: "new-wallet".to_string() },
-            CliCommand::Resolve {
-                resolve: crate::channel::Resolvable::Executable,
-            },
-            CliCommand::Resolve {
-                resolve: crate::channel::Resolvable::LibPath,
-            },
-        ];
-        let mut aliases = HashMap::new();
-        aliases.insert("my alias".to_string(), alias);
         let old_components = [
             Component {
                 name: std::borrow::Cow::Borrowed("vm"),
@@ -569,6 +561,7 @@ mod tests {
                 },
                 features: vec![String::from("executable"), String::from("concurrent")],
                 requires: Vec::new(),
+                call_format: Vec::new(),
                 rustup_channel: None,
                 installed_file: None,
                 aliases: HashMap::new(),
@@ -582,6 +575,7 @@ mod tests {
                 features: Vec::new(),
                 requires: Vec::new(),
                 rustup_channel: None,
+                call_format: Vec::new(),
                 installed_file: None,
                 aliases: HashMap::new(),
             },
@@ -594,6 +588,7 @@ mod tests {
                 features: Vec::new(),
                 requires: Vec::new(),
                 rustup_channel: None,
+                call_format: Vec::new(),
                 installed_file: None,
                 aliases: HashMap::new(),
             },
@@ -606,11 +601,11 @@ mod tests {
                 features: Vec::new(),
                 requires: Vec::new(),
                 rustup_channel: None,
+                call_format: Vec::new(),
                 installed_file: None,
-                aliases,
+                aliases: HashMap::new(),
             },
         ];
-        println!("{}", serde_json::to_string_pretty(&old_components).unwrap());
 
         let new_components = [
             Component {
@@ -622,6 +617,7 @@ mod tests {
                 features: vec![String::from("executable"), String::from("concurrent")],
                 requires: Vec::new(),
                 rustup_channel: None,
+                call_format: Vec::new(),
                 installed_file: None,
                 aliases: HashMap::new(),
             },
@@ -634,6 +630,7 @@ mod tests {
                 features: Vec::new(),
                 requires: Vec::new(),
                 rustup_channel: None,
+                call_format: Vec::new(),
                 installed_file: None,
                 aliases: HashMap::new(),
             },
@@ -646,6 +643,7 @@ mod tests {
                 features: Vec::new(),
                 requires: Vec::new(),
                 rustup_channel: None,
+                call_format: Vec::new(),
                 installed_file: None,
                 aliases: HashMap::new(),
             },
@@ -658,6 +656,7 @@ mod tests {
                 features: Vec::new(),
                 requires: Vec::new(),
                 rustup_channel: None,
+                call_format: Vec::new(),
                 installed_file: None,
                 aliases: HashMap::new(),
             },
@@ -701,6 +700,7 @@ mod tests {
             },
             features: Vec::new(),
             requires: Vec::new(),
+            call_format: Vec::new(),
             rustup_channel: None,
             installed_file: None,
             aliases: HashMap::new(),
@@ -715,6 +715,7 @@ mod tests {
             features: Vec::new(),
             requires: Vec::new(),
             rustup_channel: None,
+            call_format: Vec::new(),
             installed_file: None,
             aliases: HashMap::new(),
         }];

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -307,10 +307,12 @@ pub struct Component {
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub requires: Vec<String>,
-    /// Additional parameters to pass
+    /// Commands used to call the [[Component]]'s associated executable.
+    /// IMPORTANT: This requires the [[Component::installed_file]] field to be
+    /// an [[InstalledFile::Executable]] either explicitly or implicitly.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub call_format: Vec<CliCommand>,
+    call_format: Vec<CliCommand>,
     /// If not None, then this component requires a specific toolchain to
     /// compile.
     #[serde(default)]
@@ -462,6 +464,15 @@ impl Component {
     /// Returns the String representation under which midenup calls a component.
     pub fn get_cli_display(&self) -> String {
         format!("miden {}", self.name)
+    }
+
+    /// Returns the String representation under which midenup calls a component.
+    pub fn get_call_format(&self) -> Vec<CliCommand> {
+        if self.call_format.is_empty() {
+            vec![CliCommand::Executable]
+        } else {
+            self.call_format.clone()
+        }
     }
 }
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -261,8 +261,17 @@ pub enum CliCommand {
     },
 }
 
+enum Resolvable {
+    Executable,
+    ToolchainPath,
+}
+
 impl CliCommand {
-    pub fn resolve_command(&self, channel: &Channel) -> anyhow::Result<String> {
+    pub fn resolve_command(
+        &self,
+        channel: &Channel,
+        component: &Component,
+    ) -> anyhow::Result<String> {
         match self {
             CliCommand::Verbatim { name } => Ok(name.to_string()),
             CliCommand::Resolve { name } => {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -330,11 +330,11 @@ fn main() {
             let aliases = component.aliases.keys();
             let exe_name = component.get_installed_file();
             if let InstalledFile::Executable { ref binary_name } = exe_name {
-                let miden_prefix = format!("miden {}", component.name);
+                let miden_display = component.get_cli_display();
                 for alias in aliases {
-                    executables.push((alias.clone(), miden_prefix.clone()));
+                    executables.push((alias.clone(), miden_display.clone()));
                 }
-                executables.push((miden_prefix, binary_name.clone()));
+                executables.push((miden_display, binary_name.clone()));
             }
 
             executables

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,10 @@ enum Commands {
         channel: UserChannel,
     },
     /// Sets the system's default toolchain.
+    ///
+    /// Unlike `rustup`, midenup does *not* have a notion of directory
+    /// overrides. Instead, the `midenup set` command can be used to configure a
+    /// directory-specific toolchain.
     Override {
         /// The channel or version to set, e.g. `stable` or `0.15.0`
         #[arg(required(true), value_name = "CHANNEL", value_parser)]

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -64,8 +64,13 @@ impl Manifest {
             if contents.is_empty() {
                 return Err(ManifestError::Empty);
             }
-            serde_json::from_str::<Manifest>(&contents)
-                .map_err(|e| ManifestError::Invalid(format!("Invalid channel manifest: {e}")))
+
+            serde_json::from_str::<Manifest>(&contents).map_err(|e| {
+                ManifestError::Invalid(format!(
+                    "Invalid channel manifest in {}: {e}",
+                    path.display()
+                ))
+            })
         } else if uri.starts_with("https://") {
             let mut data = Vec::new();
             let mut handle = curl::easy::Easy::new();

--- a/src/miden_wrapper.rs
+++ b/src/miden_wrapper.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, ffi::OsString, string::ToString};
 
-use anyhow::{bail, Context};
+use anyhow::{Context, bail};
 use colored::Colorize;
 
 pub use crate::config::Config;

--- a/src/miden_wrapper.rs
+++ b/src/miden_wrapper.rs
@@ -187,7 +187,8 @@ miden help"
                     (command, aliased_arguments)
                 },
                 Ok(MidenArgument::Component(component)) => {
-                    let call_convention = dbg!(&component.call_format)
+                    let call_convention = component
+                        .get_call_format()
                         .iter()
                         .map(|argument| argument.resolve_command(channel, component, config))
                         .collect::<Result<Vec<String>, _>>()?;

--- a/src/miden_wrapper.rs
+++ b/src/miden_wrapper.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, ffi::OsString, string::ToString};
 
-use anyhow::{Context, anyhow, bail};
+use anyhow::{bail, Context};
 use colored::Colorize;
 
 pub use crate::config::Config;
@@ -120,10 +120,21 @@ pub fn miden_wrapper(
 ) -> anyhow::Result<()> {
     // Extract the target binary to execute from argv[1]
     let subcommand = {
-        let subcommand = argv.get(1).ok_or(anyhow!(
-            "No arguments were passed to `miden`. To get a list of available commands, run:
-miden help"
-        ))?;
+        let subcommand = argv.get(1).with_context(|| {
+            format!(
+                "
+{}: '{}' requires a subcommand but one was not provided
+
+{} {} <ALIAS|COMMAND>
+
+For more information, try 'miden help'.
+",
+                "error:".red().bold(),
+                "miden".yellow().bold(),
+                "Usage".bold().underline(),
+                "miden".bold(),
+            )
+        })?;
         subcommand.to_str().expect("Invalid command name: {subcommand}")
     };
 

--- a/src/miden_wrapper.rs
+++ b/src/miden_wrapper.rs
@@ -58,7 +58,6 @@ impl ToolchainEnvironment {
         if let Some(component) = self.components.iter().find(|c| c.aliases.contains_key(&argument))
         {
             let resolution = component.aliases.get(&argument).unwrap();
-            // if let Some(resolution) = self.aliases.get(&argument) {
             Ok(MidenArgument::Alias(component, resolution.clone()))
         } else if let Some(component) = self.components.iter().find(|c| c.name == argument) {
             Ok(MidenArgument::Component(component))

--- a/src/miden_wrapper.rs
+++ b/src/miden_wrapper.rs
@@ -177,7 +177,7 @@ miden help"
                 Ok(MidenArgument::Alias(component, alias_resolutions)) => {
                     let commands = alias_resolutions
                         .iter()
-                        .map(|description| description.resolve_command(channel, component))
+                        .map(|description| description.resolve_command(channel, component, config))
                         .collect::<Result<Vec<String>, _>>()?;
 
                     // SAFETY: Safe under the assumption that every alias has an

--- a/src/miden_wrapper.rs
+++ b/src/miden_wrapper.rs
@@ -184,9 +184,7 @@ miden help"
 
                     (command, aliased_arguments)
                 },
-                Ok(MidenArgument::Component(component)) => {
-                    (format!("miden {}", component.name), vec![])
-                },
+                Ok(MidenArgument::Component(component)) => (component.get_cli_display(), vec![]),
                 Err(_) => {
                     let aliases = toolchain_environment.get_aliases_display();
                     let components = toolchain_environment.get_components_display();

--- a/src/miden_wrapper.rs
+++ b/src/miden_wrapper.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, ffi::OsString, string::ToString};
 
-use anyhow::{Context, anyhow, bail};
+use anyhow::{anyhow, bail, Context};
 use colored::Colorize;
 
 pub use crate::config::Config;
@@ -35,7 +35,7 @@ enum MidenArgument<'a> {
     /// The passed argument was an Alias stored in the local [[Manifest]]. [[AliasResolution]]
     /// represents the list of commands that need to be executed. NOTE: Some of these might need
     /// to get resolved.
-    Alias(CLICommand),
+    Alias(&'a Component, CLICommand),
     /// The argument was the name of a component stored in the [[Manifest]].
     Component(&'a Component),
 }
@@ -55,8 +55,11 @@ impl ToolchainEnvironment {
     }
 
     fn resolve(&self, argument: String) -> Result<MidenArgument<'_>, EnvironmentError> {
-        if let Some(resolution) = self.aliases.get(&argument) {
-            Ok(MidenArgument::Alias(resolution.clone()))
+        if let Some(component) = self.components.iter().find(|c| c.aliases.contains_key(&argument))
+        {
+            let resolution = component.aliases.get(&argument).unwrap();
+            // if let Some(resolution) = self.aliases.get(&argument) {
+            Ok(MidenArgument::Alias(component, resolution.clone()))
         } else if let Some(component) = self.components.iter().find(|c| c.name == argument) {
             Ok(MidenArgument::Component(component))
         } else {
@@ -171,10 +174,10 @@ miden help"
         MidenSubcommand::Help(HelpMessage::Resolve(resolve))
         | MidenSubcommand::Resolve(resolve) => {
             match toolchain_environment.resolve(resolve.clone()) {
-                Ok(MidenArgument::Alias(alias_resolutions)) => {
+                Ok(MidenArgument::Alias(component, alias_resolutions)) => {
                     let commands = alias_resolutions
                         .iter()
-                        .map(|description| description.resolve_command(channel))
+                        .map(|description| description.resolve_command(channel, component))
                         .collect::<Result<Vec<String>, _>>()?;
 
                     // SAFETY: Safe under the assumption that every alias has an

--- a/src/miden_wrapper.rs
+++ b/src/miden_wrapper.rs
@@ -187,7 +187,14 @@ miden help"
 
                     (command, aliased_arguments)
                 },
-                Ok(MidenArgument::Component(component)) => (component.get_cli_display(), vec![]),
+                Ok(MidenArgument::Component(component)) => (
+                    component.get_cli_display(),
+                    component
+                        .call_format
+                        .iter()
+                        .map(|argument| argument.resolve_command(channel, component, config))
+                        .collect::<Result<Vec<String>, _>>()?,
+                ),
                 Err(_) => {
                     let aliases = toolchain_environment.get_aliases_display();
                     let components = toolchain_environment.get_components_display();


### PR DESCRIPTION
Close #83 
Close #46 
Close #94

This PR adds a new field `call_format` to components, which describes how to call the Command associated with a component. This implied refactoring the already present `CliCommand` enum. 

With this, the aliasing format present in the Manifest changed from this:
```
          "aliases": {
              "account": [{"resolve": "client"}, {"verbatim": "new-account"}],
              "faucet": [{"resolve": "client"}, {"verbatim": "mint"}],
              "deploy": [{"resolve": "client"}, {"verbatim": "new-wallet"}, {"verbatim": "--deploy"}],
              "call": [{"resolve": "client"}, {"verbatim": "call"}, {"verbatim": "--show"}],
              "send": [{"resolve": "client"}, {"verbatim": "send"}],
              "simulate": [{"resolve": "client"}, {"verbatim": "exec"}]
            }
```

To this:
```
          "aliases": {
              "account": ["executable", "new-account"]
              "faucet": ["executable", "mint"],
              "deploy": ["executable", "new-wallet", "--deploy"],
              "call": ["executable", "call", "--show"],
              "send": ["executable", "send"],
              "simulate": ["executable", "exec"]
           }
```

This field is currently used in the compiler to automatically pass the `-L` flag with the location of the Transaction Kernel and Standard libraries. In the manifest, this looks like this:
```
(...)
        {
          "name": "midenc",
          "version": "0.1.0",
          "rustup_channel": "nightly-2025-03-20",
          "call_format": ["executable", "compile", "-L", "lib_path"]
        },

(...)
```

Important sidenote: I hardcoded the "compile" subcommand into the manifest. This means that when the compiler is invoked via midenup, the "compile" subcommand is automatically appended and thus neither "run" nor "debug" can be called.
This was implemented like so because the the compiler does not recognize the `-L` flag globally. For instance, the following errors out:
```
$~ midenc -L lib/ compiler file.wasm
error: unexpected argument '-L' found

Usage: midenc <COMMAND>
``` 

This could potentially be remedied by recognizing the `-L` flag globally, and simply ignoring if not applicable to the passed subcommand.