### PR TITLE
fix: alias resolution

### DIFF
--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -31,12 +31,12 @@
           "revision": "83df2aa115b2617e211d1d929a1189ffabbd137b",
           "installed_executable": "miden-client",
           "aliases": {
-              "account": ["executable", "new-account"],
-              "faucet": ["executable", "mint"],
-              "deploy": ["executable", "new-wallet", "--deploy"],
-              "call": ["executable", "call", "--show"],
-              "send": ["executable", "send"],
-              "simulate": ["executable", "exec"]
+              "account": ["miden account", "new-account"],
+              "faucet": ["miden faucet", "mint"],
+              "deploy": ["miden deploy", "new-wallet", "--deploy"],
+              "call": ["miden call", "call", "--show"],
+              "send": ["miden send", "send"],
+              "simulate": ["miden simulate", "exec"]
           },
           "initialization": ["init"]
         },
@@ -85,12 +85,12 @@
           "version": "0.10.2",
           "installed_executable": "miden-client",
           "aliases": {
-              "account": ["executable", "new-account"],
-              "faucet": ["executable", "mint"],
-              "deploy": ["executable", "new-wallet", "--deploy"],
-              "call": ["executable", "call", "--show"],
-              "send": ["executable", "send"],
-              "simulate": ["executable", "exec"]
+              "account": ["miden account", "new-account"],
+              "faucet": ["miden faucet", "mint"],
+              "deploy": ["miden deploy", "new-wallet", "--deploy"],
+              "call": ["miden call", "call", "--show"],
+              "send": ["miden send", "send"],
+              "simulate": ["miden simulate", "exec"]
           },
           "initialization": ["init"]
         },
@@ -139,12 +139,12 @@
           "version": "0.11.8",
           "installed_executable": "miden-client",
           "aliases": {
-              "account": ["executable", "new-account"],
-              "faucet": ["executable", "mint"],
-              "deploy": ["executable", "new-wallet", "--deploy"],
-              "call": ["executable", "call", "--show"],
-              "send": ["executable", "send"],
-              "simulate": ["executable", "exec"]
+              "account": ["miden account", "new-account"],
+              "faucet": ["miden faucet", "mint"],
+              "deploy": ["miden deploy", "new-wallet", "--deploy"],
+              "call": ["miden call", "call", "--show"],
+              "send": ["miden send", "send"],
+              "simulate": ["miden simulate", "exec"]
           },
           "initialization": ["init"]
         },

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -374,7 +374,8 @@ fn main() {
             if let InstalledFile::Executable { ref binary_name } = exe_name {
                 let miden_display = component.get_cli_display();
                 for alias in aliases {
-                    executables.push((alias.clone(), binary_name.clone()));
+                    let alias_display = format!("miden {}", alias.clone());
+                    executables.push((alias_display, binary_name.clone()));
                 }
                 executables.push((miden_display, binary_name.clone()));
             }


### PR DESCRIPTION
Currently, alias resolution fails. This is because there's a name miss match between the executable symlink present in `<toolchain>/opt` and the command that `miden` executes.

This PR provides a fix.