### PR TITLE
feat: alias rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Here's a table with all the currently available aliases:
 | miden faucet     | Fund account via faucet           | miden-client mint                                                    |
 | miden new        | Create new project                | cargo miden new                                                      |
 | miden build      | Build project                     | cargo miden build                                                    |
+| miden deploy     | Deploy a contract                 | miden-client -s public --account-type regular-account-immutable-code |
 | miden new-wallet | Create a wallet                   | miden-client new-wallet --deploy                                     |
 | miden call       | Call view function (read-only)    | miden-client account --show                                          |
 | miden send       | Send transaction (state-changing) | miden-client send                                                    |

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -32,6 +32,7 @@
           "installed_executable": "miden-client",
           "aliases": {
               "account": ["executable", "new-account"],
+              "deploy": ["executable", "-s", "public", "--account-type", "regular-account-immutable-code"],
               "faucet": ["executable", "mint"],
               "new-wallet": ["executable", "new-wallet", "--deploy"],
               "call": ["executable", "call", "--show"],
@@ -86,6 +87,7 @@
           "installed_executable": "miden-client",
           "aliases": {
               "account": ["executable", "new-account"],
+              "deploy": ["executable", "-s", "public", "--account-type", "regular-account-immutable-code"],
               "faucet": ["executable", "mint"],
               "new-wallet": ["executable", "new-wallet", "--deploy"],
               "call": ["executable", "call", "--show"],
@@ -140,6 +142,7 @@
           "installed_executable": "miden-client",
           "aliases": {
               "account": ["executable", "new-account"],
+              "deploy": ["executable", "-s", "public", "--account-type", "regular-account-immutable-code"],
               "faucet": ["executable", "mint"],
               "new-wallet": ["executable", "new-wallet", "--deploy"],
               "call": ["executable", "call", "--show"],

--- a/tests/data/integration_install_from_non_cargo/channel-manifest-1.json
+++ b/tests/data/integration_install_from_non_cargo/channel-manifest-1.json
@@ -29,6 +29,7 @@
           "installed_executable": "miden-client",
           "aliases": {
               "account": ["executable", "new-account"],
+              "deploy": ["executable", "-s", "public", "--account-type", "regular-account-immutable-code"],
               "faucet": ["executable", "mint"],
               "new-wallet": ["executable", "new-wallet", "--deploy"],
               "call": ["executable", "call", "--show"],

--- a/tests/data/integration_install_from_non_cargo/channel-manifest-2.json
+++ b/tests/data/integration_install_from_non_cargo/channel-manifest-2.json
@@ -29,6 +29,7 @@
           "installed_executable": "miden-client",
           "aliases": {
               "account": ["executable", "new-account"],
+              "deploy": ["executable", "-s", "public", "--account-type", "regular-account-immutable-code"],
               "faucet": ["executable", "mint"],
               "new-wallet": ["executable", "new-wallet", "--deploy"],
               "call": ["executable", "call", "--show"],


### PR DESCRIPTION
Closes #101 

This PR renames the `miden deploy` alias to `miden new-wallet`; in order to better reflect what the command does.
The `miden deploy` alias is now used to deploy a contract via the `miden-client new-account -s public --account-type regular-account-immutable-code`.