### PR TITLE
feat: implement multi-command aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ Here's a table with all the currently available aliases:
 | miden send       | Send transaction (state-changing) | miden-client send                                                    |
 | miden simulate   | Simulate transaction (no commit)  | miden-client exec                                                    |
 
+Aliases are defined at the channel level in `manifest/channel-manifest.json`. Each alias is a pipeline of steps, and each step must specify which component's executable to run. Commands use the existing `CliCommand` tokens (`executable`, `lib_path`, `var_path`, or verbatim strings).
+
+Pipeline steps execute in order. User-provided CLI arguments are appended to the first step only.
+
 
 ### Uninstalling a toolchain
 

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -23,7 +23,10 @@
           "name": "vm",
           "package": "miden-vm",
           "version": "0.15.0",
-          "features": ["executable", "concurrent"],
+          "features": [
+            "executable",
+            "concurrent"
+          ],
           "installed_executable": "miden"
         },
         {
@@ -31,44 +34,140 @@
           "repository_url": "https://github.com/0xMiden/miden-client.git",
           "crate_name": "miden-client-cli",
           "revision": "83df2aa115b2617e211d1d929a1189ffabbd137b",
-          "installed_executable": "miden-client",
-          "aliases": {
-              "account": ["executable", "new-account"],
-              "deploy": ["executable", "-s", "public", "--account-type", "regular-account-immutable-code"],
-              "faucet": ["executable", "mint"],
-              "new-wallet": ["executable", "new-wallet", "--deploy"],
-              "call": ["executable", "call", "--show"],
-              "send": ["executable", "send"],
-              "simulate": ["executable", "exec"]
-          }
+          "installed_executable": "miden-client"
         },
         {
           "name": "midenc",
           "version": "0.1.0",
           "rustup_channel": "nightly-2025-03-20",
-          "requires": ["base", "std"],
-          "call_format": ["executable", "compile", "-L", "lib_path"]
+          "requires": [
+            "base",
+            "std"
+          ],
+          "call_format": [
+            "executable",
+            "compile",
+            "-L",
+            "lib_path"
+          ]
         },
         {
           "name": "cargo-miden",
           "version": "0.1.0",
           "rustup_channel": "nightly-2025-03-20",
-          "aliases": {
-              "new": ["cargo", "miden", "new"],
-              "build": ["cargo", "miden", "build"]
-          },
           "symlink_name": "cargo-miden"
         },
         {
           "name": "node",
           "package": "miden-node",
           "installed_executable": "miden-node",
-          "version": "0.10.1",
-          "aliases": {
-              "start-node": ["executable", "bundled", "start",  "--data-directory", "data", "--rpc.url", "http://0.0.0.0:57291"]
-          }
+          "version": "0.10.1"
         }
-      ]
+      ],
+      "aliases": {
+        "account": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "new-account"
+            ]
+          }
+        ],
+        "deploy": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "-s",
+              "public",
+              "--account-type",
+              "regular-account-immutable-code"
+            ]
+          }
+        ],
+        "faucet": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "mint"
+            ]
+          }
+        ],
+        "new-wallet": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "new-wallet",
+              "--deploy"
+            ]
+          }
+        ],
+        "call": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "call",
+              "--show"
+            ]
+          }
+        ],
+        "send": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "send"
+            ]
+          }
+        ],
+        "simulate": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "exec"
+            ]
+          }
+        ],
+        "new": [
+          {
+            "component": "cargo-miden",
+            "command": [
+              "cargo",
+              "miden",
+              "new"
+            ]
+          }
+        ],
+        "build": [
+          {
+            "component": "cargo-miden",
+            "command": [
+              "cargo",
+              "miden",
+              "build"
+            ]
+          }
+        ],
+        "start-node": [
+          {
+            "component": "node",
+            "command": [
+              "executable",
+              "bundled",
+              "start",
+              "--data-directory",
+              "data",
+              "--rpc.url",
+              "http://0.0.0.0:57291"
+            ]
+          }
+        ]
+      }
     },
     {
       "name": "0.16.0",
@@ -91,51 +190,150 @@
           "name": "vm",
           "package": "miden-vm",
           "version": "0.16.2",
-          "features": ["executable", "concurrent"],
+          "features": [
+            "executable",
+            "concurrent"
+          ],
           "installed_executable": "miden-vm"
         },
         {
           "name": "client",
           "package": "miden-client-cli",
           "version": "0.10.2",
-          "installed_executable": "miden-client",
-          "aliases": {
-              "account": ["executable", "new-account"],
-              "deploy": ["executable", "-s", "public", "--account-type", "regular-account-immutable-code"],
-              "faucet": ["executable", "mint"],
-              "new-wallet": ["executable", "new-wallet", "--deploy"],
-              "call": ["executable", "call", "--show"],
-              "send": ["executable", "send"],
-              "simulate": ["executable", "exec"]
-          }
+          "installed_executable": "miden-client"
         },
         {
           "name": "midenc",
           "version": "0.1.0",
           "rustup_channel": "nightly-2025-03-20",
-          "requires": ["base", "std"],
-          "call_format": ["executable", "compile", "-L", "lib_path"]
+          "requires": [
+            "base",
+            "std"
+          ],
+          "call_format": [
+            "executable",
+            "compile",
+            "-L",
+            "lib_path"
+          ]
         },
         {
           "name": "cargo-miden",
           "version": "0.1.0",
           "rustup_channel": "nightly-2025-03-20",
-          "aliases": {
-              "new": ["cargo", "miden", "new"],
-              "build": ["cargo", "miden", "build"]
-          },
           "symlink_name": "cargo-miden"
         },
         {
           "name": "node",
           "package": "miden-node",
           "installed_executable": "miden-node",
-          "version": "0.10.1",
-          "aliases": {
-              "start-node": ["executable", "bundled", "start",  "--data-directory", "data", "--rpc.url", "http://0.0.0.0:57291"]
-          }
+          "version": "0.10.1"
         }
-      ]
+      ],
+      "aliases": {
+        "account": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "new-account"
+            ]
+          }
+        ],
+        "deploy": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "-s",
+              "public",
+              "--account-type",
+              "regular-account-immutable-code"
+            ]
+          }
+        ],
+        "faucet": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "mint"
+            ]
+          }
+        ],
+        "new-wallet": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "new-wallet",
+              "--deploy"
+            ]
+          }
+        ],
+        "call": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "call",
+              "--show"
+            ]
+          }
+        ],
+        "send": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "send"
+            ]
+          }
+        ],
+        "simulate": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "exec"
+            ]
+          }
+        ],
+        "new": [
+          {
+            "component": "cargo-miden",
+            "command": [
+              "cargo",
+              "miden",
+              "new"
+            ]
+          }
+        ],
+        "build": [
+          {
+            "component": "cargo-miden",
+            "command": [
+              "cargo",
+              "miden",
+              "build"
+            ]
+          }
+        ],
+        "start-node": [
+          {
+            "component": "node",
+            "command": [
+              "executable",
+              "bundled",
+              "start",
+              "--data-directory",
+              "data",
+              "--rpc.url",
+              "http://0.0.0.0:57291"
+            ]
+          }
+        ]
+      }
     },
     {
       "name": "0.17.2",
@@ -158,39 +356,37 @@
           "name": "vm",
           "package": "miden-vm",
           "version": "0.17.2",
-          "features": ["executable", "concurrent"],
+          "features": [
+            "executable",
+            "concurrent"
+          ],
           "installed_executable": "miden-vm"
         },
         {
           "name": "client",
           "package": "miden-client-cli",
           "version": "0.11.8",
-          "installed_executable": "miden-client",
-          "aliases": {
-              "account": ["executable", "new-account"],
-              "deploy": ["executable", "-s", "public", "--account-type", "regular-account-immutable-code"],
-              "faucet": ["executable", "mint"],
-              "new-wallet": ["executable", "new-wallet", "--deploy"],
-              "call": ["executable", "call", "--show"],
-              "send": ["executable", "send"],
-              "simulate": ["executable", "exec"]
-          }
+          "installed_executable": "miden-client"
         },
         {
           "name": "midenc",
           "version": "0.4.1",
           "rustup_channel": "nightly-2025-07-20",
-          "requires": ["base", "std"],
-          "call_format": ["executable", "compile", "-L", "lib_path"]
+          "requires": [
+            "base",
+            "std"
+          ],
+          "call_format": [
+            "executable",
+            "compile",
+            "-L",
+            "lib_path"
+          ]
         },
         {
           "name": "cargo-miden",
           "version": "0.4.1",
           "rustup_channel": "nightly-2025-07-20",
-          "aliases": {
-              "new": ["cargo", "miden", "new"],
-              "build": ["cargo", "miden", "build"]
-          },
           "symlink_name": "cargo-miden"
         },
         {
@@ -198,12 +394,114 @@
           "repository_url": "https://github.com/lambdaclass/miden-node.git",
           "crate_name": "miden-node",
           "branch": "fabrizioorsi/create-account-data-dirs",
-          "installed_executable": "miden-node",
-          "aliases": {
-              "start-node": ["executable", "bundled", "start",  "--data-directory", "var_path", "data", "--rpc.url", "http://0.0.0.0:57291"]
-          }
+          "installed_executable": "miden-node"
         }
-      ]
+      ],
+      "aliases": {
+        "account": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "new-account"
+            ]
+          }
+        ],
+        "deploy": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "-s",
+              "public",
+              "--account-type",
+              "regular-account-immutable-code"
+            ]
+          }
+        ],
+        "faucet": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "mint"
+            ]
+          }
+        ],
+        "new-wallet": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "new-wallet",
+              "--deploy"
+            ]
+          }
+        ],
+        "call": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "call",
+              "--show"
+            ]
+          }
+        ],
+        "send": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "send"
+            ]
+          }
+        ],
+        "simulate": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "exec"
+            ]
+          }
+        ],
+        "new": [
+          {
+            "component": "cargo-miden",
+            "command": [
+              "cargo",
+              "miden",
+              "new"
+            ]
+          }
+        ],
+        "build": [
+          {
+            "component": "cargo-miden",
+            "command": [
+              "cargo",
+              "miden",
+              "build"
+            ]
+          }
+        ],
+        "start-node": [
+          {
+            "component": "node",
+            "command": [
+              "executable",
+              "bundled",
+              "start",
+              "--data-directory",
+              "var_path",
+              "data",
+              "--rpc.url",
+              "http://0.0.0.0:57291"
+            ]
+          }
+        ]
+      }
     },
     {
       "name": "0.19.1",
@@ -226,51 +524,151 @@
           "name": "vm",
           "package": "miden-vm",
           "version": "0.19.1",
-          "features": ["executable", "concurrent"],
+          "features": [
+            "executable",
+            "concurrent"
+          ],
           "installed_executable": "miden-vm"
         },
         {
           "name": "client",
           "package": "miden-client-cli",
           "version": "0.12.3",
-          "installed_executable": "miden-client",
-          "aliases": {
-              "account": ["executable", "new-account"],
-              "deploy": ["executable", "-s", "public", "--account-type", "regular-account-immutable-code"],
-              "faucet": ["executable", "mint"],
-              "new-wallet": ["executable", "new-wallet", "--deploy"],
-              "call": ["executable", "call", "--show"],
-              "send": ["executable", "send"],
-              "simulate": ["executable", "exec"]
-          }
+          "installed_executable": "miden-client"
         },
         {
           "name": "midenc",
           "version": "0.5.1",
           "rustup_channel": "nightly-2025-07-20",
-          "requires": ["base", "std"],
-          "call_format": ["executable", "compile", "-L", "lib_path"]
+          "requires": [
+            "base",
+            "std"
+          ],
+          "call_format": [
+            "executable",
+            "compile",
+            "-L",
+            "lib_path"
+          ]
         },
         {
           "name": "cargo-miden",
           "version": "0.5.1",
           "rustup_channel": "nightly-2025-07-20",
-          "aliases": {
-              "new": ["cargo", "miden", "new"],
-              "build": ["cargo", "miden", "build"]
-          },
           "symlink_name": "cargo-miden"
         },
         {
           "name": "node",
           "package": "miden-node",
           "version": "0.12.5",
-          "installed_executable": "miden-node",
-          "aliases": {
-              "start-node": ["executable", "bundled", "start",  "--data-directory", "var_path", "data", "--rpc.url", "http://0.0.0.0:57291"]
-          }
+          "installed_executable": "miden-node"
         }
-      ]
+      ],
+      "aliases": {
+        "account": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "new-account"
+            ]
+          }
+        ],
+        "deploy": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "-s",
+              "public",
+              "--account-type",
+              "regular-account-immutable-code"
+            ]
+          }
+        ],
+        "faucet": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "mint"
+            ]
+          }
+        ],
+        "new-wallet": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "new-wallet",
+              "--deploy"
+            ]
+          }
+        ],
+        "call": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "call",
+              "--show"
+            ]
+          }
+        ],
+        "send": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "send"
+            ]
+          }
+        ],
+        "simulate": [
+          {
+            "component": "client",
+            "command": [
+              "executable",
+              "exec"
+            ]
+          }
+        ],
+        "new": [
+          {
+            "component": "cargo-miden",
+            "command": [
+              "cargo",
+              "miden",
+              "new"
+            ]
+          }
+        ],
+        "build": [
+          {
+            "component": "cargo-miden",
+            "command": [
+              "cargo",
+              "miden",
+              "build"
+            ]
+          }
+        ],
+        "start-node": [
+          {
+            "component": "node",
+            "command": [
+              "executable",
+              "bundled",
+              "start",
+              "--data-directory",
+              "var_path",
+              "data",
+              "--rpc.url",
+              "http://0.0.0.0:57291"
+            ]
+          }
+        ]
+      }
     }
   ]
 }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -59,6 +59,7 @@ midenup install stable
                         alias: upstream_stable.alias.clone(),
                         tags: local_stable.tags.clone(),
                         components,
+                        aliases: upstream_stable.aliases.clone(),
                     }
                 };
 
@@ -162,6 +163,7 @@ fn update_channel(
             alias: upstream_channel.alias.clone(),
             tags: local_channel.tags.clone(),
             components,
+            aliases: upstream_channel.aliases.clone(),
         }
     };
     let mut path_warning_displayed = false;


### PR DESCRIPTION
# Summary

This PR moves aliases to channel-level pipelines so a single alias can orchestrate multiple components. This was discussed in #129 . Each step now names both the `component` and the `command` tokens, and user arguments are appended only to the first step. `miden` resolves and executes every step in order, enabling cross-component flows (for example, `miden-faucet` followed by `miden-client`, i.e. [mint command](https://github.com/0xMiden/midenup/issues/131)).

Partial toolchains retain only those aliases which steps target installed components. The manifest (`manifest/channel-manifest.json`) has been updated to the new channel-level alias shape.

# Details

## Channel-level aliases (breaking change)

Aliases are no longer stored under individual components. Each channel now has a top-level `aliases` map (`HashMap<Alias, Vec<AliasStep>>`). Each `AliasStep` must specify a `component` (the component whose executable should run for this step) and a `command` (the existing `CliCommand` tokens: `executable`, `lib_path`, `var_path`, or verbatim strings). For example:

```json
"aliases": {
  "mint": [
    { "component": "faucet", "command": ["executable", "mint"] },
    { "component": "client", "command": ["executable", "sync"] },
    { "component": "client", "command": ["executable", "consume-notes"] }
  ]
}
```

Resolution prefers the active channel’s aliases and components and falls back to the installed channel with warnings. Partial installs keep aliases only if all steps target installed components.

## Multi-step execution

`miden` now resolves and runs each alias step sequentially. User CLI arguments are appended only to the first step, and a `--help` request is appended to the first step’s arguments. A helper resolves each step to `(program, args)` using the step’s `component`.

## Note on data passing

Data passing between steps (capture and templating) is not part of this PR, but required as a subsequent PR for implementing issue #131 to finally implement the `mint` command.

Closes #129 