### PR TITLE
fix: do not create an ad-hoc channel when updating 

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -137,7 +137,7 @@ fn update_channel(
     let installed_toolchains_dir = config.midenup_home.join("toolchains");
     let toolchain_dir = installed_toolchains_dir.join(format!("{}", &local_channel.name));
 
-    let channel_to_install = upstream_channel.clone();
+    let mut channel_to_install = upstream_channel.clone();
 
     let comp_to_delete_with_motive = components_to_update(local_channel, &channel_to_install);
 
@@ -146,24 +146,6 @@ fn update_channel(
         return Ok(());
     }
 
-    let mut channel_to_install = {
-        let components_to_delete =
-            comp_to_delete_with_motive.iter().map(|(comp, _)| comp).collect::<HashSet<_>>();
-
-        let components = upstream_channel
-            .components
-            .iter()
-            .filter(|comp| components_to_delete.contains(comp))
-            .cloned()
-            .collect();
-
-        Channel {
-            name: upstream_channel.name.clone(),
-            alias: upstream_channel.alias.clone(),
-            tags: local_channel.tags.clone(),
-            components,
-        }
-    };
     let mut path_warning_displayed = false;
     let mut exes_to_uninstall = Vec::new();
     let mut libs_to_uninstall = Vec::new();


### PR DESCRIPTION
Closes #135 

This PR removes the creating of an ad-hoc channel when performing an update. 

Previously, when an update was issued an ad hoc channel was created which contained only the elements that were going to be updated. 

This ad-hoc channel was originally created to only display the updated components in the command, as to not fill the user's stdout. However, in retrospect, this is not really needed; as the other components will simply advertise themselves as already up to date.

`midenup update` output before PR: 
```shell
Installing: node
     Installed!
```

`midenup update` output after PR:
```shell
Installing: std.masp
     Already installed
Installing: base.masp
     Already installed
Installing: vm
     Already installed
Installing: client
     Already installed
Installing: midenc
     Already installed
Installing: cargo-miden
     Already installed
Installing: node
     Installed!
```

Additionally, if during update, `midenup` failed to uninstall a component, it would stop execution with an error. Now, it simply carries on.
The rationale behind this is that uninstalling a component might fail because it was already uninstalled during a previous update process which got cut off in half.