### PR TITLE
feat: add miden mint

### DIFF
--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -341,7 +341,10 @@
           "name": "faucet-client",
           "package": "miden-faucet-client",
           "version": "0.13.0",
-          "installed_executable": "miden-faucet-client"
+          "installed_executable": "miden-faucet-client",
+          "aliases": {
+            "mint": ["executable", "mint"]
+          }
         }
       ]
     }


### PR DESCRIPTION
Closes https://github.com/0xMiden/midenup/issues/138
Closes https://github.com/0xMiden/midenup/issues/131

With https://github.com/0xMiden/miden-faucet/pull/215 being implemented, all the logic required to request and consumes tokes lives entirely within the newly added `miden-faucet-client` binary.