### PR TITLE
fix: ci unit test

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -244,11 +244,9 @@ mod tests {
         let manifest = Manifest::load_from(Manifest::PUBLISHED_MANIFEST_URI)
             .expect("Failed to parse upstream manifest.");
 
-        let stable = manifest
+        let _ = manifest
             .get_channel(&UserChannel::Stable)
             .expect("Could not convert UserChannel to internal channel representation");
-
-        assert!(stable.get_component("std").is_some());
     }
 
     #[test]


### PR DESCRIPTION
After https://github.com/0xMiden/midenup/commit/c13d4ec465afde9cc540daf3b329954ec3435e5b was merged, the unit tests started failing.

This was because the `validate_published_channel_manifest` tried [getting the `std` component ](https://github.com/0xMiden/midenup/pull/145/changes#diff-a44cbf177b0e747788be2cc21913a967ce8a76f371b98a6c17cd908c400bf1a9L251)out of the manifest. This was done as additional verification step, since it was assumed that the `std` was going to be part of every toolchain.

However in the latest release, the `std` library was renamed to `core`, hence the test failed.
Since the actual line was a bit redundant, it was removed.