### PR TITLE
fix: `miden midenc`

### DIFF
--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -249,7 +249,7 @@
           "version": "0.5.1",
           "rustup_channel": "nightly-2025-07-20",
           "requires": ["base", "std"],
-          "call_format": ["executable", "compile", "-L", "lib_path"]
+          "call_format": ["executable", "-L", "lib_path"]
         },
         {
           "name": "cargo-miden",
@@ -325,7 +325,7 @@
           "version": "0.6.0",
           "rustup_channel": "nightly-2025-12-10",
           "requires": ["base", "std"],
-          "call_format": ["executable", "compile", "-L", "lib_path"]
+          "call_format": ["executable", "-L", "lib_path"]
         },
         {
           "name": "cargo-miden",


### PR DESCRIPTION
Closes #149 

Version [0.5.0](https://github.com/0xMiden/compiler/releases/tag/v0.5.0) of the compiler changed its CLI interface. There is no longer a "compile" command.

Thus, its call format needed to be updated. 

Now calling `miden midenc` correctly calls the miden compiler.