### PR TITLE
fix: cargo-miden from `miden`

### DIFF
--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -57,6 +57,7 @@
               "new": ["cargo", "miden", "new"],
               "build": ["cargo", "miden", "build"]
           },
+          "call_format": ["cargo", "miden"],
           "symlink_name": "cargo-miden"
         },
         {
@@ -124,6 +125,7 @@
               "new": ["cargo", "miden", "new"],
               "build": ["cargo", "miden", "build"]
           },
+          "call_format": ["cargo", "miden"],
           "symlink_name": "cargo-miden"
         },
         {
@@ -191,6 +193,7 @@
               "new": ["cargo", "miden", "new"],
               "build": ["cargo", "miden", "build"]
           },
+          "call_format": ["cargo", "miden"],
           "symlink_name": "cargo-miden"
         },
         {
@@ -259,6 +262,7 @@
               "new": ["cargo", "miden", "new"],
               "build": ["cargo", "miden", "build"]
           },
+          "call_format": ["cargo", "miden"],
           "symlink_name": "cargo-miden"
         },
         {
@@ -335,6 +339,7 @@
               "new": ["cargo", "miden", "new"],
               "build": ["cargo", "miden", "build"]
           },
+          "call_format": ["cargo", "miden"],
           "symlink_name": "cargo-miden"
         },
         {


### PR DESCRIPTION
Closes #151 

Calling `miden cargo-miden` was failing because it was attempting to call the cargo extension simply as `cargo-miden`. 


According to cargo documentation ([here](https://doc.rust-lang.org/book/ch14-05-extending-cargo.html)), in order for `cargo` to execute an extension, said extension needs to be present in the `$PATH` and also follow the naming convention `cargo-<name>`.

The plugin was already being stored as `cargo-miden` and it was already in the path, all that needed to change was how we invoked the process. This was achieved with the `call_format` field in the manifest.