### PR TITLE
feat: add version 0.7.0 of the compiler

### DIFF
--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -249,14 +249,14 @@
         },
         {
           "name": "midenc",
-          "version": "0.5.1",
+          "version": "0.6.0",
           "rustup_channel": "nightly-2025-07-20",
           "requires": ["base", "std"],
           "call_format": ["executable", "-L", "lib_path"]
         },
         {
           "name": "cargo-miden",
-          "version": "0.5.1",
+          "version": "0.6.0",
           "rustup_channel": "nightly-2025-07-20",
           "aliases": {
               "new": ["cargo", "miden", "new"],
@@ -326,14 +326,14 @@
         },
         {
           "name": "midenc",
-          "version": "0.6.0",
+          "version": "0.7.0",
           "rustup_channel": "nightly-2025-12-10",
           "requires": ["base", "std"],
           "call_format": ["executable", "-L", "lib_path"]
         },
         {
           "name": "cargo-miden",
-          "version": "0.6.0",
+          "version": "0.7.0",
           "rustup_channel": "nightly-2025-12-10",
           "aliases": {
               "new": ["cargo", "miden", "new"],


### PR DESCRIPTION
Note: this should only be merged when version `0.7.0` of the compiler and `cargo miden` are released.

Additionally, version `0.6.0` got moved to the previous release, since it was version 0.19 of the MidenVM (see: that version's [Cargo.toml](https://github.com/0xMiden/compiler/blob/7ba2437ebf2d1874997ca9f51841875f376cc642/Cargo.toml#L70-L71)).