### PR TITLE
feat: `midenup init` now saves the `miden` symlink in `$CARGO_HOME/bin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,11 @@ cargo install midenup && midenup init
 > Until this crate has been published to crates.io, it is only possible to
 > install using `cargo install --path .` or `cargo install --git <repo_uri>`.
 
-The `midenup init` command initializes the `$MIDENUP_HOME` directory, and symlinks `midenup` to `$MIDENUP_HOME/bin/miden` so that all of the executable Miden components can be accessed using the `miden` command.
-
-You must also ensure `$MIDENUP_HOME/bin` is added to your shell `$PATH`. You can obtain the current value of `$MIDENUP_HOME` using `midenup show home` if you don't set it explicitly. For example, you might have something like this in your shell profile (assuming a `sh`-like shell):
-
-```
-export MIDENUP_HOME=$XDG_DATA_DIR/midenup
-export PATH=${MIDENUP_HOME}/bin:$PATH
-```
+The `midenup init` command initializes the `$MIDENUP_HOME` directory, and creates a `miden` symlink in `$CARGO_HOME/bin` (default `~/.cargo/bin`) pointing to the `midenup` executable. Since Rust users typically already have `$CARGO_HOME/bin` in their PATH, the `miden` command should be available immediately.
 
 > [!WARNING]
-> If you forget to do the step above, some functionality will not work as
-> expected!
+> If `miden` is not found after running `midenup init`, ensure `$CARGO_HOME/bin`
+> is in your PATH.
 
 You are now ready to install your first toolchain!
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,6 +1,22 @@
+use std::path::PathBuf;
+
 use anyhow::Context;
 
 use crate::{Config, DEFAULT_USER_DATA_DIR, utils};
+
+/// Get the user's cargo bin directory. If the user has '$CARGO_HOME/bin' set,
+/// then use it. If not, fallback to '$HOME/.cargo/bin'.
+/// This relies on the behavior described here:
+/// https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-reads
+fn cargo_bin_dir() -> anyhow::Result<PathBuf> {
+    if let Some(cargo_home) = std::env::var_os("CARGO_HOME") {
+        return Ok(PathBuf::from(cargo_home).join("bin"));
+    }
+    if let Some(home) = dirs::home_dir() {
+        return Ok(home.join(".cargo").join("bin"));
+    }
+    anyhow::bail!("Could not determine cargo bin directory. Set CARGO_HOME or HOME.")
+}
 
 /// This functions bootstrap the `midenup` environment (creates basic directory
 /// structure, creates the miden executable symlink, etc.), if not already
@@ -12,8 +28,6 @@ use crate::{Config, DEFAULT_USER_DATA_DIR, utils};
 /// The following is a sketch of the directory tree and contents
 ///
 /// $MIDENUP_HOME
-/// |- bin/
-/// | |- miden --> $CARGO_INSTALL_DIR/midenup
 /// |- opt/
 /// | |- symlinks
 /// |- toolchains
@@ -24,6 +38,9 @@ use crate::{Config, DEFAULT_USER_DATA_DIR, utils};
 /// | | | |- std.masp
 /// |- config.toml
 /// |- manifest.json
+///
+/// Additionally, a `miden` symlink is created in `$CARGO_HOME/bin/` pointing
+/// to the midenup executable.
 pub fn setup_midenup(config: &Config) -> anyhow::Result<bool> {
     let mut already_initialized = true;
 
@@ -45,18 +62,17 @@ pub fn setup_midenup(config: &Config) -> anyhow::Result<bool> {
         already_initialized = false;
     }
 
-    let bin_dir = config.midenup_home.join("bin");
-    if !bin_dir.exists() {
-        std::fs::create_dir_all(&bin_dir).with_context(|| {
-            format!("failed to initialize MIDENUP_HOME subdirectory: '{}'", bin_dir.display())
+    // Write the symlink for `miden` to $CARGO_HOME/bin
+    let cargo_bin = cargo_bin_dir()?;
+    if !cargo_bin.exists() {
+        // In most cases, this directory should already directory
+        std::fs::create_dir_all(&cargo_bin).with_context(|| {
+            format!("failed to create cargo bin directory: '{}'", cargo_bin.display())
         })?;
-        already_initialized = false;
     }
-
-    // Write the symlink for `miden` to $MIDENUP_HOME/bin
     let current_exe =
         std::env::current_exe().expect("unable to get location of current executable");
-    let miden_exe = bin_dir.join("miden");
+    let miden_exe = cargo_bin.join("miden");
     if !miden_exe.exists() {
         utils::fs::symlink(&miden_exe, &current_exe)?;
         already_initialized = false;
@@ -99,14 +115,19 @@ pub fn setup_midenup(config: &Config) -> anyhow::Result<bool> {
 
         println!(
             "
-Could not find `miden` executable in the system's PATH. To enable it, add midenup's bin directory to your system's PATH. 
+Could not find `miden` executable in the system's PATH.
+
+The `miden` symlink was placed in $CARGO_HOME/bin ({cargo_bin_display}), which should already be \
+in your PATH if you have Rust installed. If not, ensure $CARGO_HOME/bin is in your PATH.
+
+You may also need to add midenup's opt directory for toolchain components:
 
 export MIDENUP_HOME='{midenup_home_dir}/midenup'
-export PATH=${{MIDENUP_HOME}}/bin:$PATH
 export PATH=${{MIDENUP_HOME}}/opt:$PATH
 
 To your shell's profile file.
-"
+",
+            cargo_bin_display = cargo_bin.display(),
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -390,6 +390,8 @@ Error: {}",
         #[allow(dead_code)]
         tmp_dir: TempDir,
         midenup_dir: PathBuf,
+        #[allow(dead_code)]
+        cargo_home: PathBuf,
         present_working_dir: PathBuf,
     }
 
@@ -401,7 +403,15 @@ Error: {}",
 
         let tmp_midenup_home = tmp_dir.path().join("midenup");
 
+        let tmp_cargo_home = tmp_dir.path().join("cargo");
+
         std::fs::create_dir(&tmp_present_working_directory).unwrap();
+
+        // Set CARGO_HOME in order to not use the system's default `.cargo/bin`
+        // directory.
+        unsafe {
+            std::env::set_var("CARGO_HOME", &tmp_cargo_home);
+        }
 
         std::env::set_current_dir(&tmp_present_working_directory).unwrap_or_else(|err| {
             panic!(
@@ -413,6 +423,7 @@ Error: {}",
         TestEnvironment {
             tmp_dir,
             midenup_dir: tmp_midenup_home,
+            cargo_home: tmp_cargo_home,
             present_working_dir: tmp_present_working_directory,
         }
     }
@@ -433,6 +444,7 @@ Error: {}",
         let test_env = environment_setup(test_name);
 
         let tmp_home = test_env.midenup_dir;
+        let cargo_home = test_env.cargo_home;
         let midenup_home = tmp_home.join("midenup");
 
         const FILE: &str = full_path_manifest!(
@@ -450,8 +462,9 @@ Error: {}",
 
         // We check that the basic midenup directory structure is present
         assert!(midenup_home.exists());
-        assert!(midenup_home.join("bin").exists());
         assert!(toolchain_dir.exists());
+        // The miden symlink should be in $CARGO_HOME/bin
+        assert!(cargo_home.join("bin").join("miden").exists());
 
         // Now, we install stable
         let command = Midenup::try_parse_from(["midenup", "install", "stable"]).unwrap();
@@ -543,6 +556,7 @@ Error: {}",
         let test_env = environment_setup(test_name);
 
         let tmp_home = test_env.midenup_dir;
+        let cargo_home = test_env.cargo_home;
         let midenup_home = tmp_home.join("midenup");
 
         // SIDENOTE: This tests uses a toolchain with version number 0.14.0. This
@@ -571,8 +585,9 @@ Error: {}",
 
         // midenup initialized check
         assert!(midenup_home.exists());
-        assert!(midenup_home.join("bin").exists());
         assert!(toolchain_dir.exists());
+        // The miden symlink should be in $CARGO_HOME/bin
+        assert!(cargo_home.join("bin").join("miden").exists());
 
         // Stable toolchain installed check
         let latest_toolchain = toolchain_dir.join("0.16.0");


### PR DESCRIPTION
Closes #161 

In order to reduce manual intervention with `midenup` (for situations like github actions), now `midenup init` saves the `miden` symlink in cargo's `bin` directory.