### PR TITLE
refactor: `miden` using `clap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -141,9 +141,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.85+curl-8.18.0"
+version = "0.4.87+curl-8.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0efa6142b5ecc05f6d3eaa39e6af4888b9d3939273fb592c92b7088a8cf3fdb"
+checksum = "61a460380f0ef783703dcbe909107f39c162adeac050d73c850055118b5b6327"
 dependencies = [
  "cc",
  "libc",
@@ -247,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -259,9 +259,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -275,30 +275,30 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "libc",
@@ -329,7 +329,7 @@ dependencies = [
  "serde_json",
  "tempdir",
  "thiserror",
- "toml 1.0.6+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "upon",
 ]
 
@@ -356,9 +356,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -374,9 +374,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "proc-macro2"
@@ -464,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -529,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -611,22 +611,22 @@ dependencies = [
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -640,27 +640,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "typeid"
@@ -824,6 +824,12 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "zmij"

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ format-check: ## Runs Format using nightly toolchain but only in check mode
 	cargo +nightly fmt --all --check
 
 .PHONY: lint
-lint: format clippy docs ## Runs all linting tasks at once (Clippy, formatting)
+lint: format clippy ## Runs all linting tasks at once (Clippy, formatting)
 
 # --- testing -------------------------------------------------------------------------------------
 

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -33,13 +33,19 @@
           "revision": "83df2aa115b2617e211d1d929a1189ffabbd137b",
           "installed_executable": "miden-client",
           "aliases": {
-              "account": ["executable", "new-account"],
-              "deploy": ["executable", "-s", "public", "--account-type", "regular-account-immutable-code"],
-              "faucet": ["executable", "mint"],
-              "new-wallet": ["executable", "new-wallet", "--deploy"],
-              "call": ["executable", "call", "--show"],
-              "send": ["executable", "send"],
-              "simulate": ["executable", "exec"]
+            "account": ["executable", "new-account"],
+            "deploy": [
+              "executable",
+              "-s",
+              "public",
+              "--account-type",
+              "regular-account-immutable-code"
+            ],
+            "faucet": ["executable", "mint"],
+            "new-wallet": ["executable", "new-wallet", "--deploy"],
+            "call": ["executable", "call", "--show"],
+            "send": ["executable", "send"],
+            "simulate": ["executable", "exec"]
           }
         },
         {
@@ -54,8 +60,8 @@
           "version": "0.1.0",
           "rustup_channel": "nightly-2025-03-20",
           "aliases": {
-              "new": ["cargo", "miden", "new"],
-              "build": ["cargo", "miden", "build"]
+            "new": ["cargo", "miden", "new"],
+            "build": ["cargo", "miden", "build"]
           },
           "installed_executable": "cargo-miden",
           "alias_only": true,
@@ -68,7 +74,15 @@
           "installed_executable": "miden-node",
           "version": "0.10.1",
           "aliases": {
-              "start-node": ["executable", "bundled", "start",  "--data-directory", "data", "--rpc.url", "http://0.0.0.0:57291"]
+            "start-node": [
+              "executable",
+              "bundled",
+              "start",
+              "--data-directory",
+              "data",
+              "--rpc.url",
+              "http://0.0.0.0:57291"
+            ]
           }
         }
       ]
@@ -103,13 +117,19 @@
           "version": "0.10.2",
           "installed_executable": "miden-client",
           "aliases": {
-              "account": ["executable", "new-account"],
-              "deploy": ["executable", "-s", "public", "--account-type", "regular-account-immutable-code"],
-              "faucet": ["executable", "mint"],
-              "new-wallet": ["executable", "new-wallet", "--deploy"],
-              "call": ["executable", "call", "--show"],
-              "send": ["executable", "send"],
-              "simulate": ["executable", "exec"]
+            "account": ["executable", "new-account"],
+            "deploy": [
+              "executable",
+              "-s",
+              "public",
+              "--account-type",
+              "regular-account-immutable-code"
+            ],
+            "faucet": ["executable", "mint"],
+            "new-wallet": ["executable", "new-wallet", "--deploy"],
+            "call": ["executable", "call", "--show"],
+            "send": ["executable", "send"],
+            "simulate": ["executable", "exec"]
           }
         },
         {
@@ -124,8 +144,8 @@
           "version": "0.1.0",
           "rustup_channel": "nightly-2025-03-20",
           "aliases": {
-              "new": ["cargo", "miden", "new"],
-              "build": ["cargo", "miden", "build"]
+            "new": ["cargo", "miden", "new"],
+            "build": ["cargo", "miden", "build"]
           },
           "installed_executable": "cargo-miden",
           "alias_only": true,
@@ -138,7 +158,15 @@
           "installed_executable": "miden-node",
           "version": "0.10.1",
           "aliases": {
-              "start-node": ["executable", "bundled", "start",  "--data-directory", "data", "--rpc.url", "http://0.0.0.0:57291"]
+            "start-node": [
+              "executable",
+              "bundled",
+              "start",
+              "--data-directory",
+              "data",
+              "--rpc.url",
+              "http://0.0.0.0:57291"
+            ]
           }
         }
       ]
@@ -173,13 +201,19 @@
           "version": "0.11.8",
           "installed_executable": "miden-client",
           "aliases": {
-              "account": ["executable", "new-account"],
-              "deploy": ["executable", "-s", "public", "--account-type", "regular-account-immutable-code"],
-              "faucet": ["executable", "mint"],
-              "new-wallet": ["executable", "new-wallet", "--deploy"],
-              "call": ["executable", "call", "--show"],
-              "send": ["executable", "send"],
-              "simulate": ["executable", "exec"]
+            "account": ["executable", "new-account"],
+            "deploy": [
+              "executable",
+              "-s",
+              "public",
+              "--account-type",
+              "regular-account-immutable-code"
+            ],
+            "faucet": ["executable", "mint"],
+            "new-wallet": ["executable", "new-wallet", "--deploy"],
+            "call": ["executable", "call", "--show"],
+            "send": ["executable", "send"],
+            "simulate": ["executable", "exec"]
           }
         },
         {
@@ -194,8 +228,8 @@
           "version": "0.4.1",
           "rustup_channel": "nightly-2025-07-20",
           "aliases": {
-              "new": ["cargo", "miden", "new"],
-              "build": ["cargo", "miden", "build"]
+            "new": ["cargo", "miden", "new"],
+            "build": ["cargo", "miden", "build"]
           },
           "installed_executable": "cargo-miden",
           "alias_only": true,
@@ -209,7 +243,16 @@
           "branch": "fabrizioorsi/create-account-data-dirs",
           "installed_executable": "miden-node",
           "aliases": {
-              "start-node": ["executable", "bundled", "start",  "--data-directory", "var_path", "data", "--rpc.url", "http://0.0.0.0:57291"]
+            "start-node": [
+              "executable",
+              "bundled",
+              "start",
+              "--data-directory",
+              "var_path",
+              "data",
+              "--rpc.url",
+              "http://0.0.0.0:57291"
+            ]
           }
         }
       ]
@@ -244,13 +287,19 @@
           "version": "0.12.6",
           "installed_executable": "miden-client",
           "aliases": {
-              "account": ["executable", "new-account"],
-              "deploy": ["executable", "-s", "public", "--account-type", "regular-account-immutable-code"],
-              "faucet": ["executable", "mint"],
-              "new-wallet": ["executable", "new-wallet", "--deploy"],
-              "call": ["executable", "call", "--show"],
-              "send": ["executable", "send"],
-              "simulate": ["executable", "exec"]
+            "account": ["executable", "new-account"],
+            "deploy": [
+              "executable",
+              "-s",
+              "public",
+              "--account-type",
+              "regular-account-immutable-code"
+            ],
+            "faucet": ["executable", "mint"],
+            "new-wallet": ["executable", "new-wallet", "--deploy"],
+            "call": ["executable", "call", "--show"],
+            "send": ["executable", "send"],
+            "simulate": ["executable", "exec"]
           }
         },
         {
@@ -265,8 +314,8 @@
           "version": "0.6.0",
           "rustup_channel": "nightly-2025-07-20",
           "aliases": {
-              "new": ["cargo", "miden", "new"],
-              "build": ["cargo", "miden", "build"]
+            "new": ["cargo", "miden", "new"],
+            "build": ["cargo", "miden", "build"]
           },
           "installed_executable": "cargo-miden",
           "alias_only": true,
@@ -279,7 +328,16 @@
           "version": "0.12.8",
           "installed_executable": "miden-node",
           "aliases": {
-              "start-node": ["executable", "bundled", "start",  "--data-directory", "var_path", "data", "--rpc.url", "http://0.0.0.0:57291"]
+            "start-node": [
+              "executable",
+              "bundled",
+              "start",
+              "--data-directory",
+              "var_path",
+              "data",
+              "--rpc.url",
+              "http://0.0.0.0:57291"
+            ]
           }
         },
         {
@@ -288,7 +346,7 @@
           "version": "0.4.4",
           "installed_executable": "miden-debug",
           "artifacts": [
-             "https://github.com/0xMiden/miden-debug/releases/download/v0.4.4/miden-debug-aarch64-apple-darwin"
+            "https://github.com/0xMiden/miden-debug/releases/download/v0.4.4/miden-debug-aarch64-apple-darwin"
           ]
         }
       ]
@@ -330,13 +388,19 @@
           "version": "0.13.0",
           "installed_executable": "miden-client",
           "aliases": {
-              "account": ["executable", "new-account"],
-              "deploy": ["executable", "-s", "public", "--account-type", "regular-account-immutable-code"],
-              "faucet": ["executable", "mint"],
-              "new-wallet": ["executable", "new-wallet", "--deploy"],
-              "call": ["executable", "call", "--show"],
-              "send": ["executable", "send"],
-              "simulate": ["executable", "exec"]
+            "account": ["executable", "new-account"],
+            "deploy": [
+              "executable",
+              "-s",
+              "public",
+              "--account-type",
+              "regular-account-immutable-code"
+            ],
+            "faucet": ["executable", "mint"],
+            "new-wallet": ["executable", "new-wallet", "--deploy"],
+            "call": ["executable", "call", "--show"],
+            "send": ["executable", "send"],
+            "simulate": ["executable", "exec"]
           }
         },
         {
@@ -351,8 +415,8 @@
           "version": "0.7.0",
           "rustup_channel": "nightly-2025-12-10",
           "aliases": {
-              "new": ["cargo", "miden", "new"],
-              "build": ["cargo", "miden", "build"]
+            "new": ["cargo", "miden", "new"],
+            "build": ["cargo", "miden", "build"]
           },
           "installed_executable": "cargo-miden",
           "alias_only": true,
@@ -365,7 +429,16 @@
           "version": "0.13.4",
           "installed_executable": "miden-node",
           "aliases": {
-              "start-node": ["executable", "bundled", "start",  "--data-directory", "var_path", "data", "--rpc.url", "http://0.0.0.0:57291"]
+            "start-node": [
+              "executable",
+              "bundled",
+              "start",
+              "--data-directory",
+              "var_path",
+              "data",
+              "--rpc.url",
+              "http://0.0.0.0:57291"
+            ]
           }
         },
         {
@@ -374,8 +447,8 @@
           "version": "0.4.6",
           "installed_executable": "miden-debug",
           "artifacts": [
-             "https://github.com/0xMiden/miden-debug/releases/download/v0.4.6/miden-debug-aarch64-apple-darwin",
-             "https://github.com/0xMiden/miden-debug/releases/download/v0.4.6/miden-debug-x86_64-unknown-linux-gnu"
+            "https://github.com/0xMiden/miden-debug/releases/download/v0.4.6/miden-debug-aarch64-apple-darwin",
+            "https://github.com/0xMiden/miden-debug/releases/download/v0.4.6/miden-debug-x86_64-unknown-linux-gnu"
           ]
         },
         {
@@ -390,7 +463,7 @@
       ]
     },
     {
-      "name": "0.14.3",
+      "name": "0.14.0",
       "components": [
         {
           "name": "core",
@@ -402,7 +475,7 @@
         {
           "name": "protocol",
           "package": "miden-protocol",
-          "version": "0.14.3",
+          "version": "0.14.4",
           "installed_library": "protocol.masp",
           "library_struct": "miden_protocol::ProtocolLib"
         },
@@ -416,36 +489,42 @@
         {
           "name": "client",
           "package": "miden-client-cli",
-          "version": "0.14.0",
+          "version": "0.14.4",
           "installed_executable": "miden-client",
           "aliases": {
-              "account": ["executable", "new-account"],
-              "deploy": ["executable", "-s", "public", "--account-type", "regular-account-immutable-code"],
-              "faucet": ["executable", "mint"],
-              "new-wallet": ["executable", "new-wallet", "--deploy"],
-              "call": ["executable", "call", "--show"],
-              "send": ["executable", "send"],
-              "simulate": ["executable", "exec"]
+            "account": ["executable", "new-account"],
+            "deploy": [
+              "executable",
+              "-s",
+              "public",
+              "--account-type",
+              "regular-account-immutable-code"
+            ],
+            "faucet": ["executable", "mint"],
+            "new-wallet": ["executable", "new-wallet", "--deploy"],
+            "call": ["executable", "call", "--show"],
+            "send": ["executable", "send"],
+            "simulate": ["executable", "exec"]
           },
           "artifacts": [
-             "https://github.com/0xMiden/miden-client/releases/download/v0.14.0/miden-client-aarch64-apple-darwin",
-             "https://github.com/0xMiden/miden-client/releases/download/v0.14.0/miden-client-x86_64-unknown-linux-gnu"
+            "https://github.com/0xMiden/miden-client/releases/download/v0.14.0/miden-client-aarch64-apple-darwin",
+            "https://github.com/0xMiden/miden-client/releases/download/v0.14.0/miden-client-x86_64-unknown-linux-gnu"
           ]
         },
         {
           "name": "midenc",
-          "version": "0.8.0",
+          "version": "0.8.1",
           "rustup_channel": "nightly-2025-12-10",
           "requires": ["core", "protocol"],
           "call_format": ["executable", "-L", "lib_path"]
         },
         {
           "name": "cargo-miden",
-          "version": "0.8.0",
+          "version": "0.8.1",
           "rustup_channel": "nightly-2025-12-10",
           "aliases": {
-              "new": ["cargo", "miden", "new"],
-              "build": ["cargo", "miden", "build"]
+            "new": ["cargo", "miden", "new"],
+            "build": ["cargo", "miden", "build"]
           },
           "installed_executable": "cargo-miden",
           "alias_only": true,
@@ -455,10 +534,19 @@
         {
           "name": "node",
           "package": "miden-node",
-          "version": "0.14.5",
+          "version": "0.14.9",
           "installed_executable": "miden-node",
           "aliases": {
-              "start-node": ["executable", "bundled", "start",  "--data-directory", "var_path", "data", "--rpc.url", "http://0.0.0.0:57291"]
+            "start-node": [
+              "executable",
+              "bundled",
+              "start",
+              "--data-directory",
+              "var_path",
+              "data",
+              "--rpc.url",
+              "http://0.0.0.0:57291"
+            ]
           }
         },
         {

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -47,10 +47,8 @@ impl Artifact {
     fn get_uri_for(&self, target: &TargetTriple) -> Option<String> {
         let path = if let Some(file_path) = self.0.strip_prefix("file://") {
             file_path
-        } else if let Some(url_path) = self.0.strip_prefix("https://") {
-            url_path
         } else {
-            return None;
+            self.0.strip_prefix("https://")?
         };
 
         // <component name>(-<triplet>|.masp)

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::Cow,
     collections::HashMap,
+    ffi::OsString,
     fmt::{self, Display},
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
@@ -445,7 +446,7 @@ pub fn resolve_command(
     channel: &Channel,
     component: &Component,
     config: &Config,
-) -> anyhow::Result<Vec<String>> {
+) -> anyhow::Result<Vec<OsString>> {
     let mut resolution = Vec::with_capacity(commands.len());
     let mut commands = commands.iter();
 
@@ -460,14 +461,14 @@ pub fn resolve_command(
                     )
                 })?;
 
-                resolution.push(component.get_cli_display());
+                resolution.push(OsString::from(component.get_cli_display()));
             },
             CliCommand::LibPath => {
                 let channel_dir = channel.get_channel_dir(config);
 
                 let toolchain_path = channel_dir.join("lib");
 
-                resolution.push(toolchain_path.to_string_lossy().to_string())
+                resolution.push(toolchain_path.into_os_string())
             },
             // The VarPath must be followed by a file name.
             CliCommand::VarPath => {
@@ -484,9 +485,9 @@ pub fn resolve_command(
 
                 let full_path = toolchain_path.join(directory_name);
 
-                resolution.push(full_path.to_string_lossy().to_string())
+                resolution.push(full_path.into_os_string())
             },
-            CliCommand::Verbatim(name) => resolution.push(name.to_string()),
+            CliCommand::Verbatim(name) => resolution.push(OsString::from(name)),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,7 @@
-use std::{ffi::OsString, path::PathBuf};
+use std::{
+    ffi::{OsStr, OsString},
+    path::PathBuf,
+};
 
 use anyhow::{Context, bail};
 
@@ -124,8 +127,8 @@ impl Config {
     pub fn execute_command(
         &self,
         active_toolchain: &Channel,
-        target_exe: &str,
-        args: &Vec<OsString>,
+        target_exe: &OsStr,
+        args: &[OsString],
     ) -> Result<std::process::Child, std::io::Error> {
         let toolchain_name = active_toolchain.name.to_string();
         let sysroot = self.midenup_home.join("toolchains").join(&toolchain_name);

--- a/src/miden_wrapper.rs
+++ b/src/miden_wrapper.rs
@@ -50,7 +50,7 @@ struct ExecutionEnvironment<'a> {
 }
 
 enum EnvironmentError {
-    UnkownArgument(String),
+    UnknownArgument(String),
     LibraryAsExecutable(String),
     AliasOnly(String),
 }
@@ -58,7 +58,7 @@ enum EnvironmentError {
 impl Display for EnvironmentError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self {
-            EnvironmentError::UnkownArgument(err) => write!(f, "{err}"),
+            EnvironmentError::UnknownArgument(err) => write!(f, "{err}"),
             EnvironmentError::LibraryAsExecutable(err) => write!(f, "{err}"),
             EnvironmentError::AliasOnly(err) => write!(f, "{err}"),
         }
@@ -109,7 +109,7 @@ impl<'a> ToolchainEnvironment<'a> {
         let fallback_motive = if let Some(active_channel) = self.active_channel.as_ref() {
             match resolve_argument(active_channel, &argument) {
                 Ok(arg) => return Ok(ExecutionEnvironment { argument: arg, active_channel }),
-                Err(EnvironmentError::UnkownArgument(_)) => {
+                Err(EnvironmentError::UnknownArgument(_)) => {
                     FallbackMotive::ArgumentNotInActiveChannel
                 },
                 Err(e) => return Err(e),
@@ -214,15 +214,61 @@ enum MidenSubcommand {
     Resolve(String),
 }
 
-fn parse_subcommand(subcommand: &str, argv: &[OsString]) -> MidenSubcommand {
-    match subcommand {
-        "help" | "--help" | "-h" => match argv.get(2).and_then(|c| c.to_str()) {
-            None => MidenSubcommand::Help(HelpMessage::Default),
-            Some("toolchain") => MidenSubcommand::Help(HelpMessage::Toolchain),
-            Some(other) => MidenSubcommand::Help(HelpMessage::Resolve(other.to_string())),
+/// Identifies the `--help` flag argument in clap
+const CLAP_HELP_FLAG: &str = "help_flag";
+/// Identifies the `help` subcommand in clap
+const CLAP_HELP_SUBCMD: &str = "help";
+/// Identifies the name of the component/alias argument of the `miden help` subcommand
+const CLAP_HELP_COMPONENT_ARG: &str = "alias_component";
+/// Identifies the `--version` flag argument in clap
+const CLAP_VERSION_FLAG: &str = "version";
+
+/// Builds the clap [Command] definition for the `miden` binary.
+fn build_miden_command() -> clap::Command {
+    clap::Command::new("miden")
+        .about("The Miden toolchain porcelain")
+        // We disable clap's built-in help flag and version flag because
+        // `miden` provides its own custom help and version commands.
+        .disable_help_flag(true)
+        .disable_help_subcommand(true)
+        .disable_version_flag(true)
+        // This is what allows `miden` to be dynamic.
+        .allow_external_subcommands(true)
+        // This adds support for the -h and --help flags.
+        .arg(clap::Arg::new(CLAP_HELP_FLAG).short('h').long("help").action(clap::ArgAction::SetTrue))
+        // This adds support for `miden help <alias/component>`.
+        .subcommand(
+            clap::Command::new(CLAP_HELP_SUBCMD)
+                .about("Print help information")
+                .arg(clap::Arg::new(CLAP_HELP_COMPONENT_ARG).num_args(0..=1)),
+        )
+        // This adds support for --version.
+        .arg(clap::Arg::new(CLAP_VERSION_FLAG).long("version").action(clap::ArgAction::SetTrue))
+}
+
+/// Converts clap [ArgMatches] into a [MidenSubcommand].
+fn parse_matches(matches: &clap::ArgMatches) -> MidenSubcommand {
+    if matches.get_flag(CLAP_HELP_FLAG) {
+        return MidenSubcommand::Help(HelpMessage::Default);
+    }
+    if matches.get_flag(CLAP_VERSION_FLAG) {
+        return MidenSubcommand::Version;
+    }
+    match matches.subcommand() {
+        Some((CLAP_HELP_SUBCMD, sub_matches)) => {
+            match sub_matches.get_one::<String>(CLAP_HELP_COMPONENT_ARG).map(String::as_str) {
+                // `miden help` is the same as `--help`.
+                None => MidenSubcommand::Help(HelpMessage::Default),
+                // `miden help toolchain`.
+                Some("toolchain") => MidenSubcommand::Help(HelpMessage::Toolchain),
+                // `miden help <alias/component>`.
+                Some(other) => MidenSubcommand::Help(HelpMessage::Resolve(other.to_string())),
+            }
         },
-        "--version" => MidenSubcommand::Version,
-        _ => MidenSubcommand::Resolve(subcommand.to_string()),
+        // `miden <alias/compoent>`.
+        Some((comp_or_alias, _)) => MidenSubcommand::Resolve(comp_or_alias.to_string()),
+        // `miden` alone.
+        None => MidenSubcommand::Help(HelpMessage::Default),
     }
 }
 
@@ -231,27 +277,12 @@ pub fn miden_wrapper(
     config: &Config,
     local_manifest: &mut Manifest,
 ) -> anyhow::Result<()> {
-    // Extract the target binary to execute from argv[1]
-    let subcommand = {
-        let subcommand = argv.get(1).with_context(|| {
-            format!(
-                "
-{}: '{}' requires a subcommand but one was not provided
+    let matches = build_miden_command().get_matches_from(&argv);
 
-{} {} <ALIAS|COMMAND>
+    let parsed_subcommand = parse_matches(&matches);
 
-For more information, try 'miden help'.
-",
-                "error:".red().bold(),
-                "miden".yellow().bold(),
-                "Usage".bold().underline(),
-                "miden".bold(),
-            )
-        })?;
-        subcommand.to_str().expect("Invalid command name: {subcommand}")
-    };
-
-    let parsed_subcommand = parse_subcommand(subcommand, &argv);
+    // Used in error messages further down.
+    let user_input = argv.iter().map(|s| s.to_string_lossy()).collect::<Vec<_>>().join(" ");
 
     // NOTE: We handle these case first to avoid triggering an install when help related commands
     // are run.
@@ -279,7 +310,9 @@ For more information, try 'miden help'.
         ToolchainEnvironment::new(installed_channel, partial_channel)
     };
 
-    let help_flag = match parsed_subcommand {
+    // Whether the user requested help for a specific alias or component (e.g. `miden help
+    // compile`). If true, we append "--help" to the resolved command's arguments further down.
+    let requested_help = match parsed_subcommand {
         MidenSubcommand::Help(HelpMessage::Default) => unreachable!(),
         MidenSubcommand::Help(HelpMessage::Toolchain) => {
             let help = toolchain_help(&toolchain_environment);
@@ -288,20 +321,15 @@ For more information, try 'miden help'.
 
             return Ok(());
         },
-        MidenSubcommand::Help(HelpMessage::Resolve(_)) => {
-            // NOTE: We rely on the different component's CLI interfaces to recognize the "--help"
-            // flag. Currently, this relies on the fact that clap recognizes said flag by default.
-            // Source: https://github.com/clap-rs/clap/blob/583ba4ad9a4aea71e5b852b142715acaeaaaa050/src/_features.rs#L10
-            Some(String::from("--help"))
-        },
-        _ => None,
+        MidenSubcommand::Help(HelpMessage::Resolve(_)) => true,
+        _ => false,
     };
 
     // We obtain the target executable and prefixes that are associated with the passed subcommand.
-    let (target_exe, mut prefix_args, active_channel) = match parsed_subcommand {
-        MidenSubcommand::Version => unreachable!(),
-        MidenSubcommand::Help(HelpMessage::Default) => unreachable!(),
-        MidenSubcommand::Help(HelpMessage::Toolchain) => unreachable!(),
+    let (target_exe, prefix_args, active_channel) = match parsed_subcommand {
+        MidenSubcommand::Version
+        | MidenSubcommand::Help(HelpMessage::Default)
+        | MidenSubcommand::Help(HelpMessage::Toolchain) => unreachable!(),
         // Resolution, either for help or for actual execution is the same. The only difference is
         // wheter we append "--help" at the end and if we process additional arguments.
         MidenSubcommand::Help(HelpMessage::Resolve(resolve))
@@ -315,8 +343,9 @@ For more information, try 'miden help'.
                         resolve_command(&alias_resolutions, active_channel, &component, config)?;
 
                     // SAFETY: Safe under the assumption that every alias has an associated command.
-                    let command = commands.first().unwrap().clone();
-                    let aliased_arguments: Vec<String> = commands.into_iter().skip(1).collect();
+                    let mut commands = std::collections::VecDeque::from(commands);
+                    let command = commands.pop_front().unwrap();
+                    let aliased_arguments = commands;
 
                     (command, aliased_arguments, active_channel)
                 },
@@ -324,17 +353,17 @@ For more information, try 'miden help'.
                     argument: MidenArgument::Component(component),
                     active_channel,
                 }) => {
-                    let call_convention = resolve_command(
+                    let mut call_convention = std::collections::VecDeque::from(resolve_command(
                         &component.get_call_format(),
                         active_channel,
                         &component,
                         config,
-                    )?;
+                    )?);
 
                     // SAFETY: Safe under the assumption that every call_format has at least one
                     // argument
-                    let command = call_convention.first().unwrap().clone();
-                    let args: Vec<String> = call_convention.into_iter().skip(1).collect();
+                    let command = call_convention.pop_front().unwrap();
+                    let args = call_convention;
 
                     (command, args, active_channel)
                 },
@@ -352,34 +381,35 @@ For more information, try 'miden help'.
         },
     };
 
-    let rest_of_args = if let Some(help_flag) = help_flag {
-        prefix_args.extend([help_flag]);
-        // If the user requested for help for a specific component, we skip any additional passed in
-        // arguments.
-        argv.iter().skip(argv.len())
+    // This is either --help in case the user requested for help or the
+    // remaining arguments passed by the user.
+    let remaining_args = if requested_help {
+        vec![std::ffi::OsStr::new("--help").to_os_string()]
     } else {
-        // argv is of the form:
-        //
-        // miden <alias|component> ...
-        //
-        // So we skip the first two and pass the rest to the underlying executable.
-        argv.iter().skip(2)
+        matches
+        .subcommand()
+        // Since we're using "allow_external_subcommands" all the remaining
+        // arguments are stored in the empty string "".
+        // Source: https://docs.rs/clap/latest/clap/struct.Command.html#method.allow_external_subcommands
+        .and_then(|(_, sub_matches)| sub_matches.get_many::<OsString>(""))
+        .map(|vals| vals.map(OsString::clone).collect())
+        .unwrap_or_default()
     };
 
-    let prefix_args = prefix_args.iter().map(OsString::from).chain(rest_of_args.cloned()).collect();
+    let args = prefix_args.into_iter().chain(remaining_args).collect::<Vec<_>>();
 
     let mut command = config
-        .execute_command(active_channel, &target_exe, &prefix_args)
-        .with_context(|| format!("failed to run 'miden {subcommand}'"))?;
+        .execute_command(active_channel, &target_exe, &args)
+        .with_context(|| format!("failed to run '{user_input}'"))?;
 
     let status = command.wait().with_context(|| {
-        format!("error occurred while waiting for 'miden {subcommand}' to finish executing")
+        format!("error occurred while waiting for '{user_input}' to finish executing")
     })?;
 
     if status.success() {
         Ok(())
     } else {
-        bail!("'miden {}' failed with status {}", subcommand, status.code().unwrap_or(1))
+        bail!("'{}' failed with status {}", user_input, status.code().unwrap_or(1))
     }
 }
 
@@ -516,7 +546,7 @@ fn default_help() -> String {
 
 /// Function that tries to resolve `argument` inside the `channel`.
 fn resolve_argument(channel: &Channel, argument: &str) -> Result<MidenArgument, EnvironmentError> {
-    let mut resolution = Err(EnvironmentError::UnkownArgument(format!(
+    let mut resolution = Err(EnvironmentError::UnknownArgument(format!(
         "Failed to resolve '{}': Neither known alias or component.",
         argument
     )));


### PR DESCRIPTION
Closes #182 

Before this PR, `miden` used its own parsing logic which, which was subject to common pitfalls such as https://github.com/0xMiden/midenup/issues/182.
 
This PR removes that logic and relies on `clap` for `miden`, like it is the case in `midenup`.