### PR TITLE
feat: midenup list

### DIFF
--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -45,6 +45,7 @@ impl Artifact {
     ///
     /// NOTE: The component name is required to separate the triplet from the filename in the URI.
     fn get_uri_for(&self, target: &TargetTriple) -> Option<String> {
+        #[allow(clippy::question_mark)]
         let path = if let Some(file_path) = self.0.strip_prefix("file://") {
             file_path
         } else {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -301,6 +301,7 @@ impl Display for Channel {
 }
 
 /// A special alias/tag that a channel can posses. For more information see [`Channel::alias`].
+/// These are only used for locally installed [`Channel`]s.
 #[derive(Serialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum ChannelAlias {

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -1,0 +1,28 @@
+use colored::Colorize;
+
+use crate::{config::Config, manifest::Manifest};
+
+/// List all the available [[Channels]] presents in the upstream manifest.
+pub fn list(config: &Config, local_manifest: &Manifest) {
+    let upstream_channels = config.manifest.get_channels();
+
+    let toolchains_display: Vec<String> = upstream_channels
+        .map(|channel| {
+            let channel_name = &channel.name;
+
+            let installed_indicator = if local_manifest.get_channel_by_name(&channel.name).is_some()
+            {
+                format!(" {}", "(installed)".green())
+            } else {
+                String::new()
+            };
+
+            format!("{channel_name}{installed_indicator}")
+        })
+        .collect();
+
+    println!("{}", "Available toolchains upstream:".bold().underline());
+    for toolchain in toolchains_display {
+        println!("{toolchain}");
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
 mod init;
 mod install;
+mod list;
 mod r#override;
 mod set;
 mod show;
@@ -9,6 +10,7 @@ mod update;
 pub use self::{
     init::{init, setup_midenup},
     install::install,
+    list::list,
     r#override::r#override,
     set::set,
     show::ShowCommand,

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,13 +46,15 @@ enum Commands {
         #[clap(flatten)]
         options: options::InstallationOptions,
     },
+    /// List all available toolchains
+    List,
     /// Uninstall a Miden toolchain
     Uninstall {
         /// The channel or version to install, e.g. `stable` or `0.15.0`
         #[arg(required(true), value_name = "CHANNEL", value_parser)]
         channel: channel::UserChannel,
     },
-    /// Show information about the midenup environment
+    /// Show information about the local midenup environment.
     #[command(subcommand)]
     Show(commands::ShowCommand),
     /// Sets the current active miden toolchain for the current project.
@@ -133,6 +135,10 @@ impl Commands {
         match &self {
             Self::Init => {
                 commands::init(config)?;
+                Ok(())
+            },
+            Self::List => {
+                commands::list(config, local_manifest);
                 Ok(())
             },
             Self::Install { channel, options } => {


### PR DESCRIPTION
Closes #189 

This PR adds a command called `midenup list` that displays the list of available toolchains in the upstream manifest.