### PR TITLE
fix: stores `Libraries` as `masl`

### DIFF
--- a/docs/src/getting-started/tutorial.md
+++ b/docs/src/getting-started/tutorial.md
@@ -34,5 +34,5 @@ A typical usage of midenup and miden might look like the following:
 
 7. With the generated Miden Package, an account can be created and deployed with the following command:
    ```shell title=">_ Terminal"
-   miden client new-account --account-type regular-account-updatable-code -p /path/to/package.masp
+   miden client new-account --account-type regular-account-updatable-code -p /path/to/package.masl
    ```

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -9,14 +9,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.15.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.9.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {
@@ -80,14 +80,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.16.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.10.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {
@@ -150,14 +150,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.17.2",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.11.5",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {
@@ -221,14 +221,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.19.1",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.12.4",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {
@@ -307,14 +307,14 @@
           "name": "core",
           "package": "miden-core-lib",
           "version": "0.20.3",
-          "installed_library": "core.masp",
+          "installed_library": "core.masl",
           "library_struct": "miden_core_lib::CoreLibrary"
         },
         {
           "name": "protocol",
           "package": "miden-protocol",
           "version": "0.13.3",
-          "installed_library": "protocol.masp",
+          "installed_library": "protocol.masl",
           "library_struct": "miden_protocol::ProtocolLib"
         },
         {

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -15,7 +15,7 @@ impl Artifacts {
 
 /// Holds a URI used to fetch an artifact.
 ///
-/// These URIs have the following format: `(https://|file://)<path>/<component name>(-<triplet>|.masp)`
+/// These URIs have the following format: `(https://|file://)<path>/<component name>(-<triplet>|.masl)`
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct Artifact(String);
 
@@ -24,7 +24,7 @@ pub enum TargetTriple {
     /// Custom triplet used by cargo. Since we use the same triplets as cargo, we simply copy them
     /// as-is, without any type of parsing.
     Custom(String),
-    /// Used for .masp libraries that are used in Miden VM.
+    /// Used for .masl libraries that are used in Miden VM.
     ///
     /// Components that have these libraries as artifacts only have one entry in
     /// [`Artifacts::artifacts`].
@@ -34,7 +34,7 @@ pub enum TargetTriple {
 impl TargetTriple {
     fn get_uri_extension(&self) -> String {
         match &self {
-            Self::MidenVM => String::from(".masp"),
+            Self::MidenVM => String::from(".masl"),
             Self::Custom(triplet) => triplet.to_string(),
         }
     }
@@ -53,7 +53,7 @@ impl Artifact {
             return None;
         };
 
-        // <component name>(-<triplet>|.masp)
+        // <component name>(-<triplet>|.masl)
         let uri_extension = path.split("/").last()?;
 
         let wanted_uri_extension = target.get_uri_extension();

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -366,13 +366,13 @@ pub enum InstalledFile {
         #[serde(default)]
         alias_only: bool,
     },
-    /// The component installs a MaspLibrary.
+    /// The component installs a MaslLibrary.
     #[serde(untagged)]
     Library {
         #[serde(rename = "installed_library")]
         library_name: String,
         /// This is the name of the struct which exposes the `Library::write_to_file()` function,
-        /// that is used to generate the associated `.masp` file.
+        /// that is used to generate the associated `.masl` file.
         library_struct: String,
     },
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -40,7 +40,7 @@ fn cargo_bin_dir() -> anyhow::Result<PathBuf> {
 /// | |- <channel>/
 /// | | |- bin/
 /// | | |- lib/
-/// | | | |- std.masp
+/// | | | |- std.masl
 /// |- config.toml
 /// |- manifest.json
 /// ```

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -53,7 +53,7 @@ pub fn install(
         })?;
     }
 
-    // `lib/` directory which holds MASP libraries.
+    // `lib/` directory which holds MASL libraries.
     let lib_dir = toolchain_dir.join("lib");
     if !lib_dir.exists() {
         std::fs::create_dir_all(&lib_dir).with_context(|| {
@@ -284,11 +284,11 @@ fn main() {
     let lib_dir = miden_sysroot_dir.join("lib");
     {
         {% for dep in dependencies %}
-        println!("Installing: {{ dep.name }}.masp");
+        println!("Installing: {{ dep.name }}.masl");
 
-        // Write library to $MIDEN_SYSROOT/lib/dep.masp
+        // Write library to $MIDEN_SYSROOT/lib/dep.masl
         let lib = {{ dep.exposing_function }};
-        let lib_path = lib_dir.join("{{ dep.name }}").with_extension("masp");
+        let lib_path = lib_dir.join("{{ dep.name }}").with_extension("masl");
         // NOTE: If the file already exists, then we are running an update and we
         // don't need to update this element
         if !std::fs::exists(&lib_path).expect("Can't check existence of file") {
@@ -510,7 +510,7 @@ fn main() {
                 .with_context(|| {
                     format!(
                         "Component {} is marked as library, however the manifest does not contain \
-                         the associated Library struct from where it will obtain the `.masp` \
+                         the associated Library struct from where it will obtain the `.masl` \
                          file. \nThe manifest should contain a line like the following: \
                          \nlibrary_struct: \"miden_stdlib::MidenStdLib::default()\"",
                         component.name

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -158,7 +158,7 @@ fn uninstall_channel(toolchain_dir: &PathBuf) -> Result<(), UninstallError> {
             .partition(|c| matches!(c.get_installed_file(), InstalledFile::Library { .. }));
 
     for lib in installed_libraries {
-        let lib_path = toolchain_dir.join("lib").join(lib.name.as_ref()).with_extension("masp");
+        let lib_path = toolchain_dir.join("lib").join(lib.name.as_ref()).with_extension("masl");
         std::fs::remove_file(&lib_path)
             .map_err(|err| UninstallError::FailedToDeleteFile(lib_path, err.to_string()))?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -774,7 +774,7 @@ Error: {}",
         // This update should perform the following changes:
         //
         // - Update 0.15.0's miden-vm to version 0.16.2.
-        // - Remove base.masp from 0.15.0's toolchain dir.
+        // - Remove base.masl from 0.15.0's toolchain dir.
         // - Downgrade 0.14.0's miden-vm.
         // - Add the miden-client to 0.14.0's toolchain dir
         // - Change 0.14.0's std's authority from Cargo to Git.
@@ -805,7 +805,7 @@ Error: {}",
         let vm_exe_v15 = toolchain_0_15_0.join("bin").join("miden-vm");
         let command = std::process::Command::new(vm_exe_v15).arg("--version").output().unwrap();
         assert_eq!(String::from_utf8(command.stdout).unwrap(), "miden-vm 0.16.2\n");
-        assert!(!toolchain_0_15_0.join("lib").join("base.masp").exists());
+        assert!(!toolchain_0_15_0.join("lib").join("base.masl").exists());
 
         let std_version = &local_manifest
             .get_channel(&channel::UserChannel::Version(semver::Version::new(0, 14, 0)))
@@ -1122,7 +1122,7 @@ Error: {}",
         assert!(toolchain_dir.join("0.20.3").join("bin").join("miden-vm").exists());
         assert!(toolchain_dir.join("0.20.3").join("bin").join("miden-client").exists());
         // Check that libraries are installed in the lib directory
-        assert!(toolchain_dir.join("0.20.3").join("lib").join("core.masp").exists());
+        assert!(toolchain_dir.join("0.20.3").join("lib").join("core.masl").exists());
 
         // Swap to manifest 2 (channel "0.13.0" with migration from "0.20.3")
         let manifest: &str =

--- a/tests/data/integration_install_from_non_cargo/channel-manifest-1.json
+++ b/tests/data/integration_install_from_non_cargo/channel-manifest-1.json
@@ -8,14 +8,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.15.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.9.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {

--- a/tests/data/integration_install_from_non_cargo/channel-manifest-2.json
+++ b/tests/data/integration_install_from_non_cargo/channel-manifest-2.json
@@ -8,14 +8,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.15.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.9.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {

--- a/tests/data/integration_install_uninstall_test/channel-manifest.json
+++ b/tests/data/integration_install_uninstall_test/channel-manifest.json
@@ -8,14 +8,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.15.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.9.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {
@@ -34,14 +34,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.16.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.10.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {

--- a/tests/data/integration_miden_test/channel-manifest.json
+++ b/tests/data/integration_miden_test/channel-manifest.json
@@ -8,14 +8,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.14.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.7.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {
@@ -33,14 +33,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.15.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.9.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {
@@ -59,14 +59,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.16.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.10.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {

--- a/tests/data/integration_miden_toolchain_toml/channel-manifest.json
+++ b/tests/data/integration_miden_toolchain_toml/channel-manifest.json
@@ -8,14 +8,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.14.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.7.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {
@@ -51,14 +51,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.15.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.9.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {
@@ -95,14 +95,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.16.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.10.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {

--- a/tests/data/integration_migration_test/channel-manifest-1.json
+++ b/tests/data/integration_migration_test/channel-manifest-1.json
@@ -9,7 +9,7 @@
           "name": "core",
           "package": "miden-core-lib",
           "version": "0.20.3",
-          "installed_library": "core.masp",
+          "installed_library": "core.masl",
           "library_struct": "miden_core_lib::CoreLibrary"
         },
         {

--- a/tests/data/integration_migration_test/channel-manifest-2.json
+++ b/tests/data/integration_migration_test/channel-manifest-2.json
@@ -16,7 +16,7 @@
           "name": "core",
           "package": "miden-core-lib",
           "version": "0.20.3",
-          "installed_library": "core.masp",
+          "installed_library": "core.masl",
           "library_struct": "miden_core_lib::CoreLibrary"
         },
         {

--- a/tests/data/integration_update_test/channel-manifest-1.json
+++ b/tests/data/integration_update_test/channel-manifest-1.json
@@ -8,14 +8,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.14.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.7.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {

--- a/tests/data/integration_update_test/channel-manifest-2.json
+++ b/tests/data/integration_update_test/channel-manifest-2.json
@@ -8,14 +8,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.14.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.7.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {
@@ -33,14 +33,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.15.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.9.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {

--- a/tests/data/integration_update_test/channel-manifest-3.json
+++ b/tests/data/integration_update_test/channel-manifest-3.json
@@ -9,14 +9,14 @@
           "repository_url": "https://github.com/0xMiden/miden-vm.git",
           "crate_name": "miden-stdlib",
           "revision": "d65b6b88ef0f2d1bde9afcdadb1e18b1afaebf77",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.7.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {
@@ -41,7 +41,7 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.15.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
@@ -59,14 +59,14 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.16.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
         },
         {
           "name": "base",
           "package": "miden-lib",
           "version": "0.10.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
         },
         {

--- a/tests/data/unit_test_manifest_additional/manifest-uncompilable-midenc.json
+++ b/tests/data/unit_test_manifest_additional/manifest-uncompilable-midenc.json
@@ -9,7 +9,7 @@
           "name": "std",
           "package": "miden-stdlib",
           "version": "0.15.0",
-          "installed_library": "std.masp",
+          "installed_library": "std.masl",
           "library_struct": "miden_stdlib::StdLibrary"
 
         },
@@ -17,7 +17,7 @@
           "name": "base",
           "package": "miden-lib",
           "version": "0.9.0",
-          "installed_library": "base.masp",
+          "installed_library": "base.masl",
           "library_struct": "miden_lib::MidenLib"
 
         },


### PR DESCRIPTION
Closes #191 

Store libraries as `masl` instead of `masp`. 