### PR TITLE
fix: migration bug

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     artifact::{Artifacts, TargetTriple},
     config::Config,
+    manifest::Manifest,
     toolchain::{Toolchain, ToolchainJustification},
     utils,
     version::{Authority, GitTarget},
@@ -80,15 +81,27 @@ impl Display for InstallationMotive {
     }
 }
 
-impl Channel {
-    /// If this channel has a migration tag, returns the migration strategy.
-    pub fn migrated_into(&self) -> Option<&MigrationStrategy> {
-        self.tags.iter().find_map(|tag| match tag {
-            Tags::Migration { migration } => Some(migration),
-            _ => None,
-        })
-    }
+#[derive(Debug, Clone)]
+pub enum UpstreamMatch {
+    /// The remote Channel is this Channel's upstream equivalent.
+    UpstreamCounterpart,
+    /// The remote Channel is this Channel's equivalent and got migrated.
+    Migrated(MigrationStrategy),
+}
 
+#[derive(Debug, Clone)]
+pub struct UpstreamChannel {
+    pub channel: Channel,
+    pub upstream_match: UpstreamMatch,
+}
+
+impl UpstreamChannel {
+    fn new(channel: Channel, upstream_match: UpstreamMatch) -> Self {
+        UpstreamChannel { channel, upstream_match }
+    }
+}
+
+impl Channel {
     pub fn new(
         name: semver::Version,
         alias: Option<ChannelAlias>,
@@ -230,6 +243,46 @@ impl Channel {
 
         Some(partial_channel)
     }
+
+    /// Checks wheter the channel [other] is Self's upstream counterpart.
+    /// Currently this can happen in two scenarios:
+    /// - They share the same name (i.e. version).
+    /// - The upstream version is tagged as having being migrated from self's .
+    pub fn find_upstream_counterpart(
+        &self,
+        upstream_manifest: &Manifest,
+    ) -> Option<UpstreamChannel> {
+        let mut upstream_counterpart = None;
+
+        for upstream_channel in upstream_manifest.get_channels() {
+            // They share version
+            let equal_name = self.name == upstream_channel.name;
+            if equal_name {
+                let upstream_match = UpstreamMatch::UpstreamCounterpart;
+                upstream_counterpart =
+                    Some(UpstreamChannel::new(upstream_channel.clone(), upstream_match));
+                break;
+            };
+
+            // &self was migrated to other
+            let was_migrated = upstream_channel.tags
+                .iter()
+                .find_map(|tag| {
+                    match tag {
+                        Tags::Migration { migration } => Some(migration.clone()),
+                        _ => None,
+                    }
+                });
+
+            if let Some(migration) = was_migrated {
+                let upstream_match = UpstreamMatch::Migrated(migration.clone());
+                upstream_counterpart =
+                    Some(UpstreamChannel::new(upstream_channel.clone(), upstream_match));
+                break;
+            };
+        }
+        upstream_counterpart
+    }
 }
 
 impl Eq for Component {}
@@ -250,38 +303,6 @@ impl Hash for Component {
         H: Hasher,
     {
         self.name.hash(state)
-    }
-}
-
-impl PartialEq for Channel {
-    fn eq(&self, other: &Self) -> bool {
-        // NOTE: To channels are equal regardless of their aliases
-        let equal_name = self.name == other.name;
-
-        let migrated_into = |a: &Channel, b: &Channel| {
-            a.tags.iter().any(|tag| {
-                matches!(tag, Tags::Migration {migration: MigrationStrategy::NameChange { old_channel }
-            } if old_channel == &b.name)
-            })
-        };
-
-        if !equal_name && !migrated_into(self, other) && !migrated_into(other, self) {
-            return false;
-        }
-
-        let my_components: std::collections::HashSet<Component> =
-            self.components.clone().into_iter().collect();
-
-        let other_components: std::collections::HashSet<Component> =
-            self.components.clone().into_iter().collect();
-
-        let equal_components = other_components == my_components;
-
-        if !equal_components {
-            return false;
-        }
-
-        true
     }
 }
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -264,15 +264,21 @@ impl Channel {
                 break;
             };
 
-            // &self was migrated to other
-            let was_migrated = upstream_channel.tags
-                .iter()
-                .find_map(|tag| {
-                    match tag {
-                        Tags::Migration { migration } => Some(migration.clone()),
-                        _ => None,
-                    }
-                });
+            let was_migrated = upstream_channel.tags.iter().find_map(|tag| match tag {
+                Tags::Migration { migration } => match migration {
+                    // A channel is only considered as "migrated" if it's
+                    // current name matches the "old_channel" field of an
+                    // upstream channel.
+                    MigrationStrategy::NameChange { old_channel } => {
+                        if old_channel == &self.name {
+                            Some(migration)
+                        } else {
+                            None
+                        }
+                    },
+                },
+                _ => None,
+            });
 
             if let Some(migration) = was_migrated {
                 let upstream_match = UpstreamMatch::Migrated(migration.clone());

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -5,7 +5,8 @@ use colored::Colorize;
 
 use crate::{
     channel::{
-        Channel, Component, InstalledFile, MigrationStrategy, UserChannel, is_toolchain_deleted,
+        Channel, Component, InstalledFile, MigrationStrategy, UpstreamChannel, UpstreamMatch,
+        UserChannel, is_toolchain_deleted,
     },
     commands::{self, uninstall::uninstall_executable},
     config::Config,
@@ -83,23 +84,21 @@ midenup install stable
                 .context(format!("ERROR: No installed channel found with version {version}"))?
                 .clone();
 
-            let upstream_channel = config
-                .manifest
-                .get_channel(&UserChannel::Version(version.clone()))
-                .context(format!(
+            let upstream_counterpart =
+                local_channel.find_upstream_counterpart(&config.manifest).context(format!(
                     "ERROR: Couldn't find a channel upstream with version {version}. Maybe it got \
                      removed."
                 ))?;
 
-            update_channel(config, &local_channel, upstream_channel, local_manifest, options)?
+            update_channel(config, &local_channel, &upstream_counterpart, local_manifest, options)?
         },
         None => {
             // Update all toolchains
             let mut channels_to_update = Vec::new();
             for local_channel in local_manifest.get_channels() {
-                let upstream_channel =
-                    config.manifest.get_channels().find(|up_c| *up_c == local_channel);
-                let Some(upstream_channel) = upstream_channel else {
+                let upstream_counterpart =
+                    local_channel.find_upstream_counterpart(&config.manifest);
+                let Some(upstream_channel) = upstream_counterpart else {
                     // NOTE: A bit of an edge case. If the channel is present in the local manifest
                     // but not in upstream, then it probably either:
                     //
@@ -135,23 +134,23 @@ midenup install stable
 fn update_channel(
     config: &Config,
     local_channel: &Channel,
-    upstream_channel: &Channel,
+    upstream_channel: &UpstreamChannel,
     local_manifest: &mut Manifest,
     options: &UpdateOptions,
 ) -> anyhow::Result<()> {
     let installed_toolchains_dir = config.midenup_home.join("toolchains");
     let toolchain_dir = installed_toolchains_dir.join(format!("{}", &local_channel.name));
 
-    let mut channel_to_install = upstream_channel.clone();
+    let comp_to_delete_with_motive = components_to_update(local_channel, upstream_channel);
 
-    let comp_to_delete_with_motive = components_to_update(local_channel, &channel_to_install);
+    let mut channel_to_install = upstream_channel.channel.clone();
 
     if comp_to_delete_with_motive.is_empty() {
         println!("Toolchain {} is up to date", local_channel);
         return Ok(());
     }
 
-    display_warnings(&comp_to_delete_with_motive, upstream_channel, options);
+    display_warnings(&comp_to_delete_with_motive, &upstream_channel.channel, options);
 
     let mut exes_to_uninstall = Vec::new();
     let mut libs_to_uninstall = Vec::new();
@@ -325,8 +324,11 @@ pub enum UpdateMotive {
 ///
 /// There is one notable exception to this rule which is when a channel is migrated into a different
 /// channel. In that case, every component is marked for update.
-pub fn components_to_update(older: &Channel, newer: &Channel) -> Vec<(Component, UpdateMotive)> {
-    let new_channel: HashSet<&Component> = HashSet::from_iter(newer.components.iter());
+pub fn components_to_update(
+    older: &Channel,
+    newer: &UpstreamChannel,
+) -> Vec<(Component, UpdateMotive)> {
+    let new_channel: HashSet<&Component> = HashSet::from_iter(newer.channel.components.iter());
     let current = HashSet::from_iter(older.components.iter());
 
     // This is the subset of new components present in the channel since last sync.
@@ -348,11 +350,12 @@ pub fn components_to_update(older: &Channel, newer: &Channel) -> Vec<(Component,
                 // This should't be possible, but if somehow the component is missing, then we
                 // trigger an update for said component regardless.
                 None => Some((current_component, UpdateMotive::Added)),
-                // If the new channel was migrated, then every component should be deleted; unless
-                // explicitely told otherwise by the users (for example in components which were
-                // compile from a path at a given time).
+                // Note that some components might ignore this update, such as
+                // components that were installed via the filesystem.
                 Some(new_component) => {
-                    if let Some(strategy) = newer.migrated_into() {
+                    // If the channel got marked as migrated, then every single
+                    // installed component is due for an update.
+                    if let UpstreamMatch::Migrated(strategy) = &newer.upstream_match {
                         Some((
                             current_component,
                             UpdateMotive::Migrated { strategy: strategy.clone() },


### PR DESCRIPTION
Currently, `midenup update` performed a migration when an upstream channel contained the `Migration` tag. However, the migration was triggered even when the channel had already been migrated.

This PR fixes this issue by only triggering a migration if the current channel's name matches the `Migration`'s `old_channel` field.

Additionally, the code was simplified a bit:
- `PartialEq for Channel` was removed since it was a bit too side-effect-y and was only used when finding a local `Channel`'s upstream counterpart. Similarly, `fn migrated_into` was also removed since.
- Instead, both of thses functionalities were encapsulated entirely inside the `find_upstream_counterpart` function. 