### PR TITLE
feat: add miden-verify to toolchain 0.14.0

### DIFF
--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -571,6 +571,16 @@
           "aliases": {
             "mint": ["executable", "mint"]
           }
+        },
+        {
+          "name": "verify",
+          "package": "miden-verify",
+          "version": "0.3.0",
+          "installed_executable": "miden-verify",
+          "artifacts": [
+            "https://github.com/walnuthq/miden-verify/releases/download/v0.3.0/miden-verify-aarch64-apple-darwin",
+            "https://github.com/walnuthq/miden-verify/releases/download/v0.3.0/miden-verify-x86_64-unknown-linux-gnu"
+          ]
         }
       ]
     }


### PR DESCRIPTION
This PR adds [Miden Verify](https://github.com/walnuthq/miden-verify) a CLI responsible for verifying Miden accounts and notes to midenup as a `verify` component accessible through `miden verify`.

The miden-verify CLI is just a wrapper performing API calls to a "Verification API" configurable via `--verifier-url`.

The underlying API doing the actual verification is documented here: https://walnutlabs.notion.site/Public-Miden-Contract-Verification-API-3113cefbe64b807eaa92d3c673bde0bc

At the moment a PoC implementation of this API has been released as part of the [Miden Playground](https://github.com/walnuthq/miden-playground) and is leveraged by the MidenScan explorer to display Rust source codes of verified accounts and notes.

An ongoing work is in progress to extract this verification API out of the Miden Playground project and release it as a set of self-hostable services codenamed [Miden Sourcify](https://walnutlabs.notion.site/Miden-Sourcify-PRD-33d3cefbe64b8033978ae749507bb5fe).

@lima-limon-inc This PR ends up being exactly the same as your initial suggestion #186 thanks again for your help on this!

Closes #185