### PR TITLE
docs(init): fix PATH guidance for midenup install

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ The `midenup init` command initializes the `$MIDENUP_HOME` directory, and create
 
 > [!WARNING]
 > If `miden` is not found after running `midenup init`, ensure `$CARGO_HOME/bin`
-> is in your PATH.
+> is in your PATH. On macOS with zsh, add `export PATH="$HOME/.cargo/bin:$PATH"`
+> to `~/.zprofile` and create that file first if it does not exist.
 
 You are now ready to install your first toolchain!
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -54,7 +54,15 @@ source ~/.zprofile
 
 ### For Bash
 
-Add the following to your `~/.bash_profile` file:
+Add the following to your `~/.bash_profile` file (use `~/.bashrc` on Linux). If the file does
+not exist yet, create it first:
+
+```bash title=">_ Terminal"
+touch ~/.bash_profile
+echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.bash_profile
+```
+
+If you prefer to edit the file manually, add:
 
 ```bash title=">_ Terminal"
 export PATH="$HOME/.cargo/bin:$PATH"

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -18,27 +18,32 @@ Until this crate has been published to crates.io, it is only possible to install
 midenup init
 ```
 
-The `midenup init` command initializes the `$MIDENUP_HOME` directory and creates a symlink so that all executable Miden components can be accessed using the `miden` command.
+The `midenup init` command initializes the `$MIDENUP_HOME` directory and creates a `miden`
+symlink in `$CARGO_HOME/bin` (default `~/.cargo/bin`). The `miden` command then routes to the
+active toolchain components for you.
 
 ## Configure PATH Environment Variable
 
-**This is a critical step!** You must ensure `$MIDENUP_HOME/bin` is added to your shell `$PATH`. `midenup` will automatically display the required commands for your operating system if it detects that its binaries are not accessible from the `$PATH`.
+**This is a critical step!** You must ensure the directory containing the `miden` symlink is in
+your shell `$PATH`. In a standard Rust install that is `$CARGO_HOME/bin`, which defaults to
+`~/.cargo/bin`. `midenup` will automatically display the required commands if it detects that
+`miden` is not accessible from the `$PATH`.
 
-In any case, you can always obtain the current value of `$MIDENUP_HOME` using `midenup show home`. Here's a list of manual commands
+If you use a custom `CARGO_HOME`, replace the paths below accordingly.
 
 ### For Zsh (macOS default)
 
-Add the following to your `~/.zprofile` file:
+Add the following to your `~/.zprofile` file. If the file does not exist yet, create it first:
 
 ```bash title=">_ Terminal"
-export MIDENUP_HOME="/Users/$(whoami)/Library/Application Support/midenup"
-export PATH=${MIDENUP_HOME}/bin:$PATH
+touch ~/.zprofile
+echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> ~/.zprofile
 ```
 
-Or if you want to use the default location:
+If you prefer to edit the file manually, add:
 
 ```bash title=">_ Terminal"
-export PATH="/Users/$(whoami)/Library/Application Support/midenup/bin:$PATH"
+export PATH="$HOME/.cargo/bin:$PATH"
 ```
 
 Then reload your shell configuration:
@@ -52,8 +57,7 @@ source ~/.zprofile
 Add the following to your `~/.bash_profile` file:
 
 ```bash title=">_ Terminal"
-export MIDENUP_HOME=$XDG_DATA_DIR/midenup
-export PATH=${MIDENUP_HOME}/bin:$PATH
+export PATH="$HOME/.cargo/bin:$PATH"
 ```
 
 Then reload your shell configuration:

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -121,17 +121,12 @@ pub fn setup_midenup(config: &Config) -> Result<InitializationState, Initializat
             .is_ok();
 
         if !miden_is_accessible {
-            let midenup_home_dir = if std::env::var(DEFAULT_USER_DATA_DIR).is_ok() {
-                String::from("${{XDG_DATA_HOME}}")
-            } else {
+            if std::env::var(DEFAULT_USER_DATA_DIR).is_err() {
                 // Some OSs, like MacOs, don't define the XDG_* family of environment variables. In
-                // those cases, we fall back on data_dir
+                // those cases, we mark the environment as initialized so the updated guidance
+                // below is surfaced on first-run.
                 state = InitializationState::Initialized;
-
-                dirs::data_dir()
-                    .and_then(|dir| dir.into_os_string().into_string().ok())
-                    .unwrap_or(String::from("${{HOME}}/.local/share"))
-            };
+            }
 
             println!(
                 "
@@ -141,12 +136,15 @@ The `miden` symlink was placed in $CARGO_HOME/bin ({cargo_bin_display}), which s
                  in your PATH if you have Rust installed. If not, ensure $CARGO_HOME/bin is in \
                  your PATH.
 
-You may also need to add midenup's opt directory for toolchain components:
+Add the directory containing the `miden` symlink to your shell's profile file. For the default
+Rust installation this is usually:
 
-export MIDENUP_HOME='{midenup_home_dir}/midenup'
-export PATH=${{MIDENUP_HOME}}/opt:$PATH
+export PATH=\"{cargo_bin_display}:$PATH\"
 
-To your shell's profile file.
+On macOS with zsh, add that line to ~/.zprofile (create the file first if it does not exist),
+then start a new shell or run:
+
+source ~/.zprofile
 ",
                 cargo_bin_display = cargo_bin.display(),
             );


### PR DESCRIPTION
## Summary
- update the install docs to point users at the `miden` symlink created in `$CARGO_HOME/bin` instead of the stale `$MIDENUP_HOME/bin` path
- clarify the zsh/macOS flow by explicitly mentioning `~/.zprofile` creation
- update `midenup init`'s PATH warning text to match the actual install layout

## Why
`midenup init` creates a `miden` symlink under Cargo's bin directory, but the docs and warning text still send users toward paths that do not match the current setup. That makes first-run installation more confusing than it needs to be.

## Testing
- `git diff --check`
- did not run Rust tests locally because this machine does not have `cargo` installed

Related to #171
