### PR TITLE
feat: semver-ize manifest_version on the `manifest.json`

### DIFF
--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": "1.0",
+  "manifest_version": "1.0.0",
   "date": 1749330054,
   "channels": [
     {


### PR DESCRIPTION
Adds patch version to the `manifest.json`

This issue came up in https://github.com/0xMiden/midenup/pull/201, where now the manifest struct holds a `semver` field instead of a plain str. 


The `0.1` version upstream caused the tests on #201 to fail parsing the upstream manifest.