### PR TITLE
chore: add v0.15 to channel manifest

### DIFF
--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -665,19 +665,7 @@
           "name": "node",
           "package": "miden-node",
           "version": "0.15.0",
-          "installed_executable": "miden-node",
-          "aliases": {
-            "start-node": [
-              "executable",
-              "bundled",
-              "start",
-              "--data-directory",
-              "var_path",
-              "data",
-              "--rpc.url",
-              "http://0.0.0.0:57291"
-            ]
-          }
+          "installed_executable": "miden-node"
         },
         {
           "name": "debug",

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -668,6 +668,24 @@
           "installed_executable": "miden-node"
         },
         {
+          "name": "validator",
+          "package": "miden-validator",
+          "version": "0.15.0",
+          "installed_executable": "miden-validator"
+        },
+        {
+          "name": "ntx-builder",
+          "package": "miden-ntx-builder",
+          "version": "0.15.0",
+          "installed_executable": "miden-ntx-builder"
+        },
+        {
+          "name": "remote-prover",
+          "package": "miden-remote-prover",
+          "version": "0.15.0",
+          "installed_executable": "miden-remote-prover"
+        },
+        {
           "name": "debug",
           "package": "miden-debug",
           "version": "0.8.1",
@@ -680,7 +698,11 @@
           "installed_executable": "miden-faucet-client",
           "aliases": {
             "mint": ["executable", "mint"]
-          }
+          },
+          "artifacts": [
+            "https://github.com/0xMiden/miden-faucet/releases/download/v0.15.1/miden-faucet-client-aarch64-apple-darwin",
+            "https://github.com/0xMiden/miden-faucet/releases/download/v0.15.1/miden-faucet-client-x86_64-unknown-linux-gnu"
+          ]
         },
         {
           "name": "verify",

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": "1.0.0",
-  "date": 1749330054,
+  "date": 1782222096,
   "channels": [
     {
       "name": "0.9.0",
@@ -567,6 +567,128 @@
           "name": "faucet-client",
           "package": "miden-faucet-client",
           "version": "0.14.0",
+          "installed_executable": "miden-faucet-client",
+          "aliases": {
+            "mint": ["executable", "mint"]
+          }
+        },
+        {
+          "name": "verify",
+          "package": "miden-verify",
+          "version": "0.3.0",
+          "installed_executable": "miden-verify",
+          "artifacts": [
+            "https://github.com/walnuthq/miden-verify/releases/download/v0.3.0/miden-verify-aarch64-apple-darwin",
+            "https://github.com/walnuthq/miden-verify/releases/download/v0.3.0/miden-verify-x86_64-unknown-linux-gnu"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "0.15.0",
+      "components": [
+        {
+          "name": "core",
+          "package": "miden-core-lib",
+          "version": "0.23.3",
+          "installed_library": "core.masp",
+          "library_struct": "miden_core_lib::CoreLibrary"
+        },
+        {
+          "name": "protocol",
+          "package": "miden-protocol",
+          "version": "0.15.3",
+          "installed_library": "protocol.masp",
+          "library_struct": "miden_protocol::ProtocolLib"
+        },
+        {
+          "name": "vm",
+          "package": "miden-vm",
+          "version": "0.23.3",
+          "features": ["executable", "concurrent"],
+          "installed_executable": "miden-vm"
+        },
+        {
+          "name": "client",
+          "package": "miden-client-cli",
+          "version": "0.15.2",
+          "installed_executable": "miden-client",
+          "aliases": {
+            "account": ["executable", "new-account"],
+            "deploy": [
+              "executable",
+              "-s",
+              "public",
+              "--account-type",
+              "regular-account-immutable-code"
+            ],
+            "faucet": ["executable", "mint"],
+            "new-wallet": ["executable", "new-wallet", "--deploy"],
+            "call": ["executable", "call", "--show"],
+            "send": ["executable", "send"],
+            "simulate": ["executable", "exec"]
+          },
+          "artifacts": [
+            "https://github.com/0xMiden/rust-sdk/releases/download/v0.15.2/miden-client-aarch64-apple-darwin",
+            "https://github.com/0xMiden/rust-sdk/releases/download/v0.15.2/miden-client-x86_64-unknown-linux-gnu"
+          ]
+        },
+        {
+          "name": "midenc",
+          "version": "0.8.1",
+          "rustup_channel": "nightly-2025-12-10",
+          "requires": ["core", "protocol"],
+          "call_format": ["executable", "-L", "lib_path"],
+          "artifacts": [
+            "https://github.com/0xMiden/compiler/releases/download/v0.8.1/midenc-aarch64-apple-darwin",
+            "https://github.com/0xMiden/compiler/releases/download/v0.8.1/midenc-x86_64-unknown-linux-gnu"
+          ]
+        },
+        {
+          "name": "cargo-miden",
+          "version": "0.8.1",
+          "rustup_channel": "nightly-2025-12-10",
+          "aliases": {
+            "new": ["cargo", "miden", "new"],
+            "build": ["cargo", "miden", "build"]
+          },
+          "installed_executable": "cargo-miden",
+          "alias_only": true,
+          "call_format": ["cargo", "miden"],
+          "symlink_name": "cargo-miden",
+          "artifacts": [
+            "https://github.com/0xMiden/compiler/releases/download/v0.8.1/cargo-miden-aarch64-apple-darwin",
+            "https://github.com/0xMiden/compiler/releases/download/v0.8.1/cargo-miden-x86_64-unknown-linux-gnu"
+          ]
+        },
+        {
+          "name": "node",
+          "package": "miden-node",
+          "version": "0.15.0",
+          "installed_executable": "miden-node",
+          "aliases": {
+            "start-node": [
+              "executable",
+              "bundled",
+              "start",
+              "--data-directory",
+              "var_path",
+              "data",
+              "--rpc.url",
+              "http://0.0.0.0:57291"
+            ]
+          }
+        },
+        {
+          "name": "debug",
+          "package": "miden-debug",
+          "version": "0.8.1",
+          "installed_executable": "miden-debug"
+        },
+        {
+          "name": "faucet-client",
+          "package": "miden-faucet-client",
+          "version": "0.15.1",
           "installed_executable": "miden-faucet-client",
           "aliases": {
             "mint": ["executable", "mint"]


### PR DESCRIPTION
Closes https://github.com/0xMiden/midenup/issues/212

Updates the `channel-manifest.json` to add the new v0.15 release artifacts. Notably, the miden-node binary has now been divided into 4 separate binaries (`node`, `validator`, `ntx-builder`, `remote-prover`).

This manifest can be tested by running: 
```
MIDENUP_MANIFEST_URI=file://<path-to-new-manifest> midenup install stable
```

TODO:
- ~Re-add the `miden start-node` alias. We need to define where should the node startup logic live, since the `bundled` command does not exist anymore~. EDIT: This has been decided to be removed from midenup, docker-compose will fill this use.
- Decide if we want to keep all the node binaries. Keeping them would increase installing times and might not be useful for the average user.