### PR TITLE
Upgrade miden client to 0.15.3 and update docs with miden call command

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Here's a table with all the currently available aliases:
 | miden build      | Build project                     | cargo miden build                                                    |
 | miden deploy     | Deploy a contract                 | miden-client -s public --account-type regular-account-immutable-code |
 | miden new-wallet | Create a wallet                   | miden-client new-wallet --deploy                                     |
-| miden call       | Call view function (read-only)    | miden-client account --show                                          |
+| miden call       | Call a procedure on an account    | miden-client call                                                    |
 | miden send       | Send transaction (state-changing) | miden-client send                                                    |
 | miden simulate   | Simulate transaction (no commit)  | miden-client exec                                                    |
 

--- a/docs/src/design/miden.md
+++ b/docs/src/design/miden.md
@@ -9,6 +9,6 @@ Once installed, components can be called directly with `miden <component-name>`.
 
 ## Aliases
 
-Since some tasks in Miden development come up frequently, the `miden` CLI is also aware of a number of aliases. This include things like compiling a project, creating an account, deploying a local node, etc.
+Since some tasks in Miden development come up frequently, the `miden` CLI is also aware of a number of aliases. This include things like compiling a project, creating an account, calling a procedure on an account, deploying a local node, etc.
 
 The list of currently available aliases can be found with `miden help toolchain`. Aliases are channel specific, so different channels may have different number of aliases all together. A typical usage of these aliases can be found on the [tutorial](../getting-started/tutorial.md)

--- a/docs/src/getting-started/tutorial.md
+++ b/docs/src/getting-started/tutorial.md
@@ -36,3 +36,12 @@ A typical usage of midenup and miden might look like the following:
    ```shell title=">_ Terminal"
    miden client new-account --account-type regular-account-updatable-code -p /path/to/package.masp
    ```
+
+8. Once the account exists, a procedure exported by the package can be invoked on it with the `miden call` alias. This calls the procedure on the local account and displays both its return value and the resulting account state delta:
+   ```shell title=">_ Terminal"
+   miden call <ACCOUNT_ID>:<PROCEDURE> --package /path/to/package.masp
+   ```
+   For example, to call the `increment_count` procedure exported by a counter contract:
+   ```shell title=">_ Terminal"
+   miden call 0x29b8...f1:increment_count --package /path/to/counter-contract.masp
+   ```

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -893,13 +893,17 @@
         {
           "name": "client",
           "package": "miden-client-cli",
-          "version": "0.15.2",
+          "version": "0.15.3",
           "installed_executable": "miden-client",
           "alias_only": false,
           "aliases": {
             "account": [
               "executable",
               "new-account"
+            ],
+            "call": [
+              "executable",
+              "call"
             ],
             "deploy": [
               "executable",
@@ -927,8 +931,8 @@
             ]
           },
           "artifacts": [
-            "https://github.com/0xMiden/miden-client/releases/download/v0.15.2/miden-client-aarch64-apple-darwin",
-            "https://github.com/0xMiden/miden-client/releases/download/v0.15.2/miden-client-x86_64-unknown-linux-gnu"
+            "https://github.com/0xMiden/miden-client/releases/download/v0.15.3/miden-client-aarch64-apple-darwin",
+            "https://github.com/0xMiden/miden-client/releases/download/v0.15.3/miden-client-x86_64-unknown-linux-gnu"
           ]
         },
         {

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -931,8 +931,8 @@
             ]
           },
           "artifacts": [
-            "https://github.com/0xMiden/miden-client/releases/download/v0.15.3/miden-client-aarch64-apple-darwin",
-            "https://github.com/0xMiden/miden-client/releases/download/v0.15.3/miden-client-x86_64-unknown-linux-gnu"
+            "https://github.com/0xMiden/rust-sdk/releases/download/v0.15.3/miden-client-aarch64-apple-darwin",
+            "https://github.com/0xMiden/rust-sdk/releases/download/v0.15.3/miden-client-x86_64-unknown-linux-gnu"
           ]
         },
         {

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -30,10 +30,10 @@ pub fn install(
     commands::setup_midenup(config, local_manifest)?;
 
     let toolchains_dir = config.midenup_home.join("toolchains");
-    let toolchain_dir = toolchains_dir.join(format!("{}", &channel.name));
+    let toolchain_dir = toolchains_dir.join(format!("{}", channel.name));
 
     let installed_toolchains_dir = config.midenup_home.join("installed_toolchains");
-    let install_dir_name = format!("{}-{}", &channel.name, channel.content_hash());
+    let install_dir_name = format!("{}-{}", channel.name, channel.content_hash());
     let install_dir = installed_toolchains_dir.join(&install_dir_name);
 
     // Relative path to the newly installed channel directory.
@@ -137,7 +137,7 @@ pub fn install(
         )
     }
 
-    let temp_symlink = installed_toolchains_dir.join(format!("{}.new", &channel.name));
+    let temp_symlink = installed_toolchains_dir.join(format!("{}.new", channel.name));
     if std::fs::symlink_metadata(&temp_symlink).is_ok() {
         std::fs::remove_file(&temp_symlink).with_context(|| {
             format!("failed to remove stale temp symlink '{}'", temp_symlink.display())
@@ -171,7 +171,7 @@ pub fn install(
         if stable_dir.exists() {
             std::fs::remove_file(&stable_dir).context("Couldn't remove stable symlink")?;
         }
-        let relative_channel_target = PathBuf::from(format!("{}", &channel.name));
+        let relative_channel_target = PathBuf::from(format!("{}", channel.name));
         utils::fs::symlink(&stable_dir, &relative_channel_target)
             .expect("Couldn't create stable dir");
     }

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -28,7 +28,7 @@ impl ShowCommand {
                 let (toolchain, justification) = Toolchain::current(config)?;
 
                 if !verbose {
-                    println!("{}", &toolchain.channel);
+                    println!("{}", toolchain.channel);
                 } else {
                     match justification {
                         ToolchainJustification::MidenToolchainFile { path } => {
@@ -51,7 +51,7 @@ impl ShowCommand {
                             );
                         },
                     }
-                    println!("The current active toolchain is {}", &toolchain.channel);
+                    println!("The current active toolchain is {}", toolchain.channel);
                 }
 
                 Ok(())

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -44,7 +44,7 @@ pub fn uninstall(
     };
 
     let toolchains_dir = config.midenup_home.join("toolchains");
-    let toolchain_symlink = toolchains_dir.join(format!("{}", &local_channel.name));
+    let toolchain_symlink = toolchains_dir.join(format!("{}", local_channel.name));
 
     let installed_channel_dir = toolchain_symlink.canonicalize();
 
@@ -126,7 +126,7 @@ pub fn uninstall_components(
             .partition(|c| matches!(c.get_installed_file(), InstalledFile::Library { .. }));
 
     for lib in installed_libraries {
-        println!("removing previous version of component {}", &lib.name);
+        println!("removing previous version of component {}", lib.name);
         let lib_path = install_dir.join("lib").join(lib.name.as_ref()).with_extension("masp");
         // Only remove the file if it exists - treat inability to determine existence as
         // non-existent
@@ -137,7 +137,7 @@ pub fn uninstall_components(
     }
 
     for exe in installed_executables {
-        println!("removing previous version of component {}", &exe.name);
+        println!("removing previous version of component {}", exe.name);
         let opt_path = install_dir.join("opt").join(exe.get_symlink_name());
         let _ = std::fs::remove_file(&opt_path);
 

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -36,7 +36,7 @@ midenup install stable
             )?;
             println!(
                 "syncing channel updates for stable (last update was {last_updated} as {})",
-                &local_stable.name
+                local_stable.name
             );
             let upstream_stable = config
                 .manifest
@@ -49,7 +49,7 @@ midenup install stable
 
             println!(
                 "latest stable is version {} (upstream last updated on {})",
-                &upstream_stable.name,
+                upstream_stable.name,
                 config.manifest.last_updated()
             );
 
@@ -99,7 +99,7 @@ midenup install stable
 
             println!(
                 "syncing channel updates for {} (last update was {last_updated})",
-                &local_channel.name
+                local_channel.name
             );
 
             let upstream_counterpart =
@@ -134,7 +134,7 @@ midenup install stable
             for (local_channel, upstream_channel) in channels_to_update {
                 println!(
                     "syncing channel updates for {} (last update was {last_updated})",
-                    &local_channel.name
+                    local_channel.name
                 );
                 println!("upstream last updated on {}", config.manifest.last_updated());
                 update_channel(config, &local_channel, &upstream_channel, local_manifest, options)?;
@@ -188,7 +188,7 @@ fn update_channel(
 
     display_warnings(&update, options);
 
-    println!("Updating toolchain {}..", &local_channel.name);
+    println!("Updating toolchain {}..", local_channel.name);
 
     let Update {
         channel_to_install,

--- a/src/migration/atomic_installation.rs
+++ b/src/migration/atomic_installation.rs
@@ -24,7 +24,7 @@ pub fn migrate_toolchain(config: &Config, local_manifest: &Manifest) -> anyhow::
             continue;
         }
 
-        let install_dir_name = format!("{}-{}", &channel.name, hash);
+        let install_dir_name = format!("{}-{}", channel.name, hash);
         let install_dir = installed_toolchains_dir.join(&install_dir_name);
 
         std::fs::create_dir_all(&install_dir).with_context(|| {

--- a/tools/update-manifest/src/main.rs
+++ b/tools/update-manifest/src/main.rs
@@ -174,7 +174,7 @@ impl Cli {
                     bail!(
                         "component '{name}' already exists for toolchain '{}' - use \
                          update-component to modify it",
-                        &channel.name
+                        channel.name
                     );
                 }
                 let mut component = Component::new(name.clone(), authority.clone());
@@ -186,7 +186,7 @@ impl Cli {
                         bail!(
                             "cannot require componennt '{required}': unknown component for \
                              toolchain '{}'",
-                            &channel.name
+                            channel.name
                         );
                     }
                     component.requires.push(required.clone());
@@ -200,7 +200,7 @@ impl Cli {
                     bail!("unknown toolchain '{channel}'")
                 };
                 if channel.get_component(name.as_str()).is_none() {
-                    bail!("unknown component '{name}' for toolchain '{}'", &channel.name);
+                    bail!("unknown component '{name}' for toolchain '{}'", channel.name);
                 }
                 channel.components.retain_mut(|c| c.name != name.as_str());
                 manifest.update_last_modified();
@@ -224,7 +224,7 @@ impl Cli {
                         bail!(
                             "cannot require componennt '{required}': unknown component for \
                              toolchain '{}'",
-                            &channel.name
+                            channel.name
                         );
                     }
                 }
@@ -232,7 +232,7 @@ impl Cli {
                     bail!(
                         "unknown component '{name}' for toolchain '{}' - use add-component to \
                          create it",
-                        &channel.name
+                        channel.name
                     );
                 };
                 let prev_version = match &component.version {


### PR DESCRIPTION
Upgrade the ‎`miden-client` to version `0.15.3` and document the new ‎`miden call` alias, including usage examples in the getting started tutorial.

Closes #197 