### PR TITLE
feat: explicit toolchain overrides for `miden`

### DIFF
--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": "3.0.0",
-  "date": 1786289283,
+  "date": 1786377658,
   "networks": {
     "devnet": "0.16.0",
     "mainnet": "0.15.0",
@@ -1771,43 +1771,6 @@
       "components": [
         {
           "aliases": {
-            "new": [
-              "cargo",
-              "miden",
-              "new"
-            ]
-          },
-          "artifacts": {
-            "cargo-miden": {
-              "targets": {
-                "aarch64-apple-darwin": {},
-                "x86_64-unknown-linux-gnu": {}
-              },
-              "uri": "https://github.com/0xMiden/compiler/releases/download/v%version/cargo-miden-%target"
-            }
-          },
-          "call-format": [
-            "cargo",
-            "miden"
-          ],
-          "hide": true,
-          "installation_method": {
-            "kind": "prebuilt"
-          },
-          "installed-executable": "cargo-miden",
-          "kind": "cargo-extension",
-          "name": "cargo-miden",
-          "profiles": [
-            "minimal"
-          ],
-          "symlink-name": "cargo-miden",
-          "version": {
-            "kind": "registry",
-            "version": "0.10.0-rc.1"
-          }
-        },
-        {
-          "aliases": {
             "account": [
               "%installed-executable",
               "new-account"
@@ -1941,45 +1904,6 @@
           }
         },
         {
-          "aliases": {
-            "build": [
-              "%installed-executable"
-            ]
-          },
-          "artifacts": {
-            "midenc": {
-              "targets": {
-                "aarch64-apple-darwin": {},
-                "x86_64-unknown-linux-gnu": {}
-              },
-              "uri": "https://github.com/0xMiden/compiler/releases/download/v%version/midenc-%target"
-            }
-          },
-          "call-format": [
-            "%installed-executable",
-            "-L",
-            "%lib"
-          ],
-          "hide": false,
-          "installation_method": {
-            "kind": "prebuilt"
-          },
-          "installed-executable": "midenc",
-          "kind": "executable",
-          "name": "midenc",
-          "profiles": [
-            "minimal"
-          ],
-          "requires": [
-            "core",
-            "protocol"
-          ],
-          "version": {
-            "kind": "registry",
-            "version": "0.10.0-rc.1"
-          }
-        },
-        {
           "artifacts": {
             "bootstrap.yml": {
               "uri": "https://raw.githubusercontent.com/0xMiden/node/refs/tags/v%version/compose/bootstrap.yml"
@@ -2077,21 +2001,6 @@
               "-d"
             ]
           },
-          "version": {
-            "kind": "registry",
-            "version": "0.16.0-alpha.3"
-          }
-        },
-        {
-          "hide": false,
-          "installation_method": {
-            "crate_name": "miden-ntx-builder",
-            "kind": "cargo",
-            "rustup_channel": "1.96"
-          },
-          "installed-executable": "miden-ntx-builder",
-          "kind": "executable",
-          "name": "ntx-builder",
           "version": {
             "kind": "registry",
             "version": "0.16.0-alpha.3"

--- a/src/commands/override.rs
+++ b/src/commands/override.rs
@@ -26,7 +26,7 @@ pub fn r#override(
 
     // We check which toolchain is active in order to inform the user in case the `override` command
     // won't take effect.
-    let (active, justification) = Toolchain::current(config)?;
+    let (active, justification) = Toolchain::current(config, None)?;
 
     let toolchains_dir = config.midenup_home.join("toolchains");
     let channel_dir = match channel {

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -25,7 +25,7 @@ impl ShowCommand {
     pub fn execute(&self, config: &Config, state: &LocalState) -> anyhow::Result<()> {
         match self {
             Self::Current { verbose } => {
-                let (toolchain, justification) = Toolchain::current(config)?;
+                let (toolchain, justification) = Toolchain::current(config, None)?;
 
                 if !verbose {
                     println!("{}", toolchain.channel);
@@ -43,6 +43,9 @@ impl ShowCommand {
                                 "{}: system default has been overridden via `midenup override`",
                                 "info".white().bold(),
                             )
+                        },
+                        ToolchainJustification::Requested => {
+                            println!("{}: explicitly requested by user", "info".white().bold(),)
                         },
                         ToolchainJustification::Default => {
                             println!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -290,7 +290,29 @@ impl Config {
         let sysroot = self.midenup_home.join("toolchains").join(&toolchain_name);
         let toolchain_opt = sysroot.join("opt");
 
-        let path = match std::env::var_os("PATH") {
+        // Get the current PATH, and override CARGO_HOME if it differs from the inherited CARGO_HOME
+        let (cargo_home, path) = match std::env::var_os("CARGO_HOME") {
+            Some(inherited) if inherited.as_os_str() == self.cargo_home.as_os_str() => {
+                (inherited, std::env::var_os("PATH"))
+            },
+            Some(_) => match std::env::var_os("PATH") {
+                Some(prev_path) => {
+                    let mut path =
+                        OsString::from(format!("{}:", self.cargo_home.join("bin").display()));
+                    path.push(prev_path);
+                    (self.cargo_home.clone().into_os_string(), Some(path))
+                },
+                None => {
+                    let cargo_home = self.cargo_home.clone().into_os_string();
+                    let path = self.cargo_home.join("bin").into_os_string();
+                    (cargo_home, Some(path))
+                },
+            },
+            None => (self.cargo_home.clone().into_os_string(), std::env::var_os("PATH")),
+        };
+
+        // Prepend the toolchain opt/ directory to the current PATH
+        let path = match path {
             Some(prev_path) => {
                 let mut path = OsString::from(format!("{}:", toolchain_opt.display()));
                 path.push(prev_path);
@@ -304,6 +326,7 @@ impl Config {
             .env("MIDENUP_HOME", &self.midenup_home)
             .env("MIDENUP_TOOLCHAIN", &toolchain_name)
             .env("MIDEN_SYSROOT", &sysroot)
+            .env("CARGO_HOME", cargo_home)
             .env("PATH", path)
             .args(args);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use std::{
     borrow::Cow,
     ffi::{OsStr, OsString},
     path::PathBuf,
+    rc::Rc,
 };
 
 use anyhow::Context;
@@ -60,6 +61,10 @@ pub struct Config {
     /// be rare), we fail to obtain the system's target triple, then we leave it as `None`. In
     /// those cases, we will simply install everything from source.
     pub target: Cow<'static, str>,
+    /// The output of the child process executed by the `miden` CLI
+    capture_output: Option<Rc<core::cell::RefCell<std::process::Output>>>,
+    /// An optional input buffer that should replace the inherited standard input of the process
+    pipe_stdin: Option<Vec<u8>>,
 }
 
 impl Config {
@@ -80,7 +85,32 @@ impl Config {
             manifest: std::cell::OnceCell::new(),
             debug,
             target,
+            capture_output: None,
+            pipe_stdin: None,
         })
+    }
+
+    /// Enables output capture for child processes of the `miden` CLI
+    ///
+    /// Returns a ref-counted cell that wraps the output captured from the child process.
+    /// Callers should only attempt to access the buffer contents after `miden` has finished
+    /// executing.
+    pub fn capture_output(&mut self) -> Rc<core::cell::RefCell<std::process::Output>> {
+        if let Some(captured) = self.capture_output.clone() {
+            return captured;
+        }
+        let capture_output = Rc::new(core::cell::RefCell::new(std::process::Output {
+            status: Default::default(),
+            stderr: Default::default(),
+            stdout: Default::default(),
+        }));
+        self.capture_output = Some(capture_output.clone());
+        capture_output
+    }
+
+    /// Pipes `buffer` to child processes of `miden`, rather than inheriting the parent's stdin.
+    pub fn pipe_stdin(&mut self, buffer: Vec<u8>) {
+        assert!(self.pipe_stdin.replace(buffer).is_none(), "input has already been redirected");
     }
 
     /// The upstream manifest, fetched on first use.
@@ -167,7 +197,7 @@ impl Config {
     /// *local* state: asking upstream which channel `mainnet` names would put a network round trip
     /// after every component invocation, which is exactly what section 13.1 forbids.
     pub fn update_opt_symlinks(&self) -> anyhow::Result<()> {
-        let (current_toolchain, _) = Toolchain::current(self)?;
+        let (current_toolchain, _) = Toolchain::current(self, None)?;
 
         // Directory which point to the directory where symlinks are stored
         let opt_dir = self.midenup_home.join("opt");
@@ -255,7 +285,7 @@ impl Config {
         active_toolchain: &Channel,
         target_exe: &OsStr,
         args: &[OsString],
-    ) -> Result<std::process::Child, std::io::Error> {
+    ) -> Result<std::process::ExitStatus, std::io::Error> {
         let toolchain_name = active_toolchain.name.to_string();
         let sysroot = self.midenup_home.join("toolchains").join(&toolchain_name);
         let toolchain_opt = sysroot.join("opt");
@@ -269,14 +299,48 @@ impl Config {
             None => toolchain_opt.into_os_string(),
         };
 
-        std::process::Command::new(target_exe)
+        let mut command = std::process::Command::new(target_exe);
+        command
             .env("MIDENUP_HOME", &self.midenup_home)
             .env("MIDENUP_TOOLCHAIN", &toolchain_name)
             .env("MIDEN_SYSROOT", &sysroot)
             .env("PATH", path)
-            .args(args)
-            .stderr(std::process::Stdio::inherit())
-            .stdout(std::process::Stdio::inherit())
-            .spawn()
+            .args(args);
+
+        if self.pipe_stdin.is_some() {
+            command.stdin(std::process::Stdio::piped());
+        }
+
+        if self.capture_output.is_some() {
+            command
+                .stderr(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::piped());
+        } else {
+            command
+                .stderr(std::process::Stdio::inherit())
+                .stdout(std::process::Stdio::inherit());
+        }
+
+        let mut child = command.spawn()?;
+
+        if let Some(bytes) = self.pipe_stdin.clone() {
+            let mut stdin = child.stdin.take().expect("failed to open stdin");
+            std::thread::spawn(move || {
+                use std::io::Write;
+
+                stdin.write_all(&bytes).expect("failed to write to stdin");
+            });
+        }
+
+        if let Some(capture_output) = self.capture_output.as_deref() {
+            let std::process::Output { status, stderr, stdout } = child.wait_with_output()?;
+            let mut capture_output = capture_output.borrow_mut();
+            capture_output.status = status;
+            capture_output.stderr = stderr;
+            capture_output.stdout = stdout;
+            Ok(status)
+        } else {
+            child.wait()
+        }
     }
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -670,9 +670,10 @@ mod tests {
         )
         .unwrap();
 
-        let mut child =
-            config.execute_command(&channel, probe.as_os_str(), &[]).expect("should spawn");
-        assert!(child.wait().unwrap().success());
+        let exit_status = config
+            .execute_command(&channel, probe.as_os_str(), &[])
+            .expect("should execute");
+        assert!(exit_status.success());
 
         let reported = std::fs::read_to_string(&reported).expect("the probe must have run");
         let mut lines = reported.lines();

--- a/src/miden_wrapper.rs
+++ b/src/miden_wrapper.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, ffi::OsString, string::ToString};
+use std::{borrow::Cow, collections::VecDeque, ffi::OsString, string::ToString};
 
 use anyhow::{Context, anyhow, bail};
 use colored::Colorize;
@@ -39,6 +39,7 @@ enum EnvironmentError {
 }
 
 /// These are the know help messages variants that midenup is aware of.
+#[derive(Debug)]
 enum HelpMessage<'a> {
     /// Show the default help message, similar to the one you would get with clap's "--help" flag.
     Default,
@@ -255,6 +256,7 @@ impl<'a> ToolchainEnvironment<'a> {
 }
 
 /// These are the possible types of subcommands that `miden` is aware of.
+#[derive(Debug)]
 enum MidenSubcommand<'a> {
     /// Aliases that correspond to a tuple of a known component + a set of prefixed arguments.
     ///
@@ -336,7 +338,7 @@ fn parse_matches(matches: &clap::ArgMatches) -> MidenSubcommand<'_> {
                 }),
             }
         },
-        // `miden <alias/compoent>`.
+        // `miden <alias/component>`.
         Some((comp_or_alias, matches)) => {
             MidenSubcommand::Resolve { command: comp_or_alias, matches }
         },
@@ -350,8 +352,21 @@ pub fn miden_wrapper(
     config: &Config,
     state: &mut LocalState,
 ) -> anyhow::Result<()> {
-    let matches = build_miden_command().get_matches_from(argv);
+    // Handle toolchain overrides given via `miden +channel`
+    let (toolchain_override, argv) = match argv {
+        [miden, first, rest @ ..]
+            if miden.eq_ignore_ascii_case("miden")
+                && let Some(channel) = first.to_str().and_then(|s| s.strip_prefix("+")) =>
+        {
+            let mut argv = Vec::with_capacity(1 + rest.len());
+            argv.push(miden.clone());
+            argv.extend_from_slice(rest);
+            (Some(channel), Cow::Owned(argv))
+        },
+        argv => (None, Cow::Borrowed(argv)),
+    };
 
+    let matches = build_miden_command().get_matches_from(argv.as_ref());
     let parsed_subcommand = parse_matches(&matches);
 
     // NOTE: We handle these case first to avoid triggering an install when help related commands
@@ -366,11 +381,11 @@ pub fn miden_wrapper(
             return Ok(());
         },
         _ => (),
-    }
+    };
 
     // Make sure we know the current toolchain so we can modify the PATH appropriately
     let (toolchain, _justification, partial_channel) =
-        Toolchain::ensure_current_is_installed(config, state)?;
+        Toolchain::ensure_current_is_installed(config, state, toolchain_override)?;
 
     // Resolved entirely from local state. `state.json` records what is installed, and
     // `toolchains/<network>` records the last answer upstream gave about which channel that
@@ -492,15 +507,9 @@ pub fn miden_wrapper(
         },
     };
 
-    let mut command =
-        config.execute_command(active_channel, &target_exe, &args).with_context(|| {
-            let user_input = argv.iter().map(|s| s.to_string_lossy()).collect::<Vec<_>>().join(" ");
-            format!("failed to run '{user_input}'")
-        })?;
-
-    let status = command.wait().with_context(|| {
+    let status = config.execute_command(active_channel, &target_exe, &args).with_context(|| {
         let user_input = argv.iter().map(|s| s.to_string_lossy()).collect::<Vec<_>>().join(" ");
-        format!("error occurred while waiting for '{user_input}' to finish executing")
+        format!("failed to run '{user_input}'")
     })?;
 
     if status.success() {
@@ -542,7 +551,7 @@ pub fn display_version(config: &Config) -> String {
     };
     let cargo_version = cargo_version.trim();
 
-    let toolchain_version = Toolchain::current(config)
+    let toolchain_version = Toolchain::current(config, None)
         .and_then(|(toolchain, _)| {
             // `midenup --version` is informational and must not reach for the network.
             config

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -54,6 +54,8 @@ pub enum ToolchainJustification {
     MidenToolchainFile { path: PathBuf },
     /// The system's default toolchain was overriden (via `midenup set`).
     Override,
+    /// The toolchain was explicitly requested by the user
+    Requested,
     /// No toolchain was specified, fallback to the default network.
     Default,
 }
@@ -89,16 +91,31 @@ impl Toolchain {
 
     /// Returns the current active Toolchain according to the following prescedence:
     ///
-    /// 1. The toolchain specified by a `miden-toolchain.toml` file in the present working directory
-    /// 2. The toolchain that has been set as the system's default. If set, a `default` symlink is
+    /// 1. An explicit toolchain specified on the command-line
+    /// 2. The toolchain specified by a `miden-toolchain.toml` file in the present working directory
+    /// 3. The toolchain that has been set as the system's default. If set, a `default` symlink is
     ///    added to the `midenup` directory.
     ///
     /// If none of the previous conditions are met, then the default network (`mainnet`) is used.
-    pub fn current(config: &Config) -> anyhow::Result<(Toolchain, ToolchainJustification)> {
+    pub fn current(
+        config: &Config,
+        toolchain_override: Option<&str>,
+    ) -> anyhow::Result<(Toolchain, ToolchainJustification)> {
         let local_toolchain = Self::toolchain_file(&config.working_directory);
         let global_toolchain = config.midenup_home.join("toolchains").join("default");
 
-        if let Some(local_toolchain) = local_toolchain {
+        if let Some(channel_name) = toolchain_override {
+            let channel = channel_name
+                .parse::<UserChannel>()
+                .with_context(|| format!("invalid channel name '{channel_name}'"))?;
+            let toolchain = Toolchain {
+                channel,
+                components: vec![],
+                profile: None,
+            };
+
+            Ok((toolchain, ToolchainJustification::Requested))
+        } else if let Some(local_toolchain) = local_toolchain {
             let toolchain_file_contents =
                 std::fs::read_to_string(&local_toolchain).with_context(|| {
                     format!("unable to read toolchain file '{}'", local_toolchain.display())
@@ -144,8 +161,9 @@ impl Toolchain {
     pub fn ensure_current_is_installed(
         config: &Config,
         state: &mut LocalState,
+        toolchain_override: Option<&str>,
     ) -> anyhow::Result<(Self, ToolchainJustification, Option<Channel>)> {
-        let (current_toolchain, justification) = Toolchain::current(config)?;
+        let (current_toolchain, justification) = Toolchain::current(config, toolchain_override)?;
         let desired_channel = &current_toolchain.channel;
 
         // Resolve the project's declared toolchain into an exact component set. An omitted
@@ -180,6 +198,8 @@ impl Toolchain {
                     ToolchainJustification::MidenToolchainFile { path } => {
                         Cow::Owned(format!("it is set in {}", path.display()))
                     },
+                    ToolchainJustification::Requested =>
+                        Cow::Borrowed("it was explicitly requested on the command line"),
                     ToolchainJustification::Override =>
                         Cow::Borrowed("it was set using 'midenup set'"),
                 }

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -109,9 +109,7 @@ impl OfflineFixture {
         let vm_script = format!(
             r#"#!/bin/sh
 
-if [ "$1" == "help" ] || [ "$1" == "--help" ]; then
-    echo "miden-vm {channel}"
-fi
+echo "miden-vm {channel}"
 
 exit 0
 "#,

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -37,13 +37,35 @@ use std::path::{Path, PathBuf};
 /// binary -- running it, or checking Cargo/git/path authority handling -- should keep using the
 /// real manifest.
 pub struct OfflineFixture {
+    pub manifest_path: PathBuf,
     /// `file://`-style URI to hand to `test_setup`.
     pub manifest_uri: String,
     /// Where the fixture's artifacts and manifest live.
     pub dir: PathBuf,
+    devnet: String,
+    mainnet: String,
+    testnet: String,
+    channels: Vec<serde_json::Value>,
 }
 
 impl OfflineFixture {
+    pub fn new(root: &Path) -> Self {
+        let dir = root.join("offline-fixture");
+        std::fs::create_dir_all(&dir).expect("failed to create fixture dir");
+        let manifest_path = dir.join("channel-manifest.json");
+        let manifest_uri = format!("file://{}", manifest_path.display());
+
+        Self {
+            manifest_path,
+            manifest_uri,
+            dir,
+            devnet: String::new(),
+            mainnet: String::new(),
+            testnet: String::new(),
+            channels: vec![],
+        }
+    }
+
     /// Builds a channel containing one of each installable shape.
     ///
     /// * `vm`     -- a prebuilt executable, so `bin/` and `opt/` are exercised
@@ -51,13 +73,51 @@ impl OfflineFixture {
     /// * `assets` -- an asset, so `etc/<component>/` is exercised
     ///
     /// Artifacts are target-agnostic so the fixture is not tied to the host triple.
-    pub fn build(root: &Path, channel: &str) -> Self {
-        let dir = root.join("offline-fixture");
-        std::fs::create_dir_all(&dir).expect("failed to create fixture dir");
+    pub fn create(root: &Path, channel: &str) -> Self {
+        Self::new(root).with_channel(channel).build()
+    }
+
+    /// Finalizes the manifest for this fixture and writes it to the fixture directory
+    pub fn build(mut self) -> Self {
+        let channels = core::mem::take(&mut self.channels);
+        let manifest = serde_json::json!({
+            "manifest_version": "3.0.0",
+            "date": 1735689600,
+            "networks": {"devnet": self.devnet.clone(), "mainnet": self.mainnet.clone(), "testnet": self.testnet.clone()},
+            "channels": channels
+        });
+
+        std::fs::write(&self.manifest_path, serde_json::to_string_pretty(&manifest).unwrap())
+            .expect("failed to write fixture manifest");
+
+        self
+    }
+
+    /// Adds a new channel, `channel`, to the set of channels in this fixture
+    pub fn with_channel(mut self, channel: &str) -> Self {
+        if self.channels.is_empty() {
+            self.mainnet = channel.to_string();
+            self.testnet = self.mainnet.clone();
+            self.devnet = self.mainnet.clone();
+        }
+
+        let dir = self.dir.join(channel);
+        std::fs::create_dir_all(&dir).expect("failed to create fixture channel dir");
 
         // A stand-in executable that behaves well enough to be run with `--help`.
         let vm_binary = dir.join("miden-vm");
-        std::fs::write(&vm_binary, "#!/bin/sh\nexit 0\n").expect("failed to write fixture binary");
+        let vm_script = format!(
+            r#"#!/bin/sh
+
+if [ "$1" == "help" ] || [ "$1" == "--help" ]; then
+    echo "miden-vm {channel}"
+fi
+
+exit 0
+"#,
+            channel = channel
+        );
+        std::fs::write(&vm_binary, &vm_script).expect("failed to write fixture binary");
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -73,48 +133,36 @@ impl OfflineFixture {
 
         let uri = |path: &Path| format!("file://{}", path.display());
 
-        let manifest = serde_json::json!({
-            "manifest_version": "3.0.0",
-            "date": 1735689600,
-            "networks": {"devnet": channel, "mainnet": channel, "testnet": channel},
-            "channels": [{
-                "name": channel,
-                "components": [
-                    {
-                        "name": "vm",
-                        "version": {"kind": "registry", "version": "0.1.0"},
-                        "kind": "executable",
-                        "installation_method": {"kind": "prebuilt"},
-                        "installed-executable": "miden-vm",
-                        "profiles": ["minimal"],
-                        "artifacts": {"miden-vm": {"uri": uri(&vm_binary)}}
-                    },
-                    {
-                        "name": "core",
-                        "version": {"kind": "registry", "version": "0.1.0"},
-                        "kind": "package",
-                        "profiles": ["minimal"],
-                        "artifacts": {"core.masp": {"uri": uri(&core_package)}}
-                    },
-                    {
-                        "name": "assets",
-                        "version": {"kind": "registry", "version": "0.1.0"},
-                        "kind": "asset",
-                        "profiles": ["complete"],
-                        "artifacts": {"config.yml": {"uri": uri(&asset)}}
-                    }
-                ]
-            }]
-        });
+        self.channels.push(serde_json::json!({
+            "name": channel,
+            "components": [
+                {
+                    "name": "vm",
+                    "version": {"kind": "registry", "version": "0.1.0"},
+                    "kind": "executable",
+                    "installation_method": {"kind": "prebuilt"},
+                    "installed-executable": "miden-vm",
+                    "profiles": ["minimal"],
+                    "artifacts": {"miden-vm": {"uri": uri(&vm_binary)}}
+                },
+                {
+                    "name": "core",
+                    "version": {"kind": "registry", "version": "0.1.0"},
+                    "kind": "package",
+                    "profiles": ["minimal"],
+                    "artifacts": {"core.masp": {"uri": uri(&core_package)}}
+                },
+                {
+                    "name": "assets",
+                    "version": {"kind": "registry", "version": "0.1.0"},
+                    "kind": "asset",
+                    "profiles": ["complete"],
+                    "artifacts": {"config.yml": {"uri": uri(&asset)}}
+                }
+            ]
+        }));
 
-        let manifest_path = dir.join("channel-manifest.json");
-        std::fs::write(&manifest_path, serde_json::to_string_pretty(&manifest).unwrap())
-            .expect("failed to write fixture manifest");
-
-        Self {
-            manifest_uri: format!("file://{}", manifest_path.display()),
-            dir,
-        }
+        self
     }
 }
 

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -61,7 +61,7 @@ fn write_toolchain_file(project: &Path, components: &[&str]) {
 fn integration_concurrent_activations_converge_on_a_superset() {
     let _guard = common::harness::mutating_test_guard();
     let env = environment_setup("concurrent_activations");
-    let fixture = common::harness::OfflineFixture::build(env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(env.tmp_dir.path(), "0.15.0");
 
     // A `miden` symlink to the binary under test.
     let bin = env.tmp_dir.path().join("bin");
@@ -138,7 +138,7 @@ fn integration_concurrent_activations_converge_on_a_superset() {
 fn integration_dispatch_against_an_installed_toolchain_makes_no_network_request() {
     let _guard = common::harness::mutating_test_guard();
     let env = environment_setup("offline_dispatch");
-    let fixture = common::harness::OfflineFixture::build(env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(env.tmp_dir.path(), "0.15.0");
 
     // Install with a reachable manifest...
     let install = Command::new(env!("CARGO_BIN_EXE_midenup"))
@@ -197,7 +197,7 @@ fn integration_dispatch_against_an_installed_toolchain_makes_no_network_request(
 fn integration_an_operation_needing_upstream_falls_back_to_the_cached_manifest() {
     let _guard = common::harness::mutating_test_guard();
     let env = environment_setup("cached_upstream");
-    let fixture = common::harness::OfflineFixture::build(env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(env.tmp_dir.path(), "0.15.0");
 
     let midenup = |manifest_uri: &str, args: &[&str]| {
         Command::new(env!("CARGO_BIN_EXE_midenup"))

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -14,7 +14,7 @@ fn integration_gc_removes_orphans_and_never_touches_referenced_publications() {
     let _guard = common::harness::mutating_test_guard();
     let test_env = environment_setup("integration_gc");
 
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
     let channel = semver::Version::new(0, 15, 0);
 

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -20,7 +20,7 @@ fn integration_install_stable() {
 
     // Offline fixture: this test asserts on recorded state and symlink layout, none of which
     // needs a real toolchain. See `OfflineFixture` for why that matters.
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
 
     Midenup::try_parse_from(["midenup", "install", "stable"])
@@ -65,7 +65,7 @@ fn integration_install_places_every_artifact_kind() {
     let _guard = common::harness::mutating_test_guard();
     let test_env = environment_setup("integration_install_places_every_artifact_kind");
 
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
 
     Midenup::try_parse_from(["midenup", "install", "stable", "--profile", "complete"])
@@ -101,7 +101,7 @@ fn integration_install_creates_default_symlinks() {
     let _guard = common::harness::mutating_test_guard();
     let test_env = environment_setup("integration_install_creates_default_symlinks");
 
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
 
     Midenup::try_parse_from(["midenup", "install", "stable"])
@@ -128,7 +128,7 @@ fn integration_install_publishes_into_an_opaque_publication_with_a_receipt() {
     let _guard = common::harness::mutating_test_guard();
     let test_env = environment_setup("integration_install_publishes");
 
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
 
     Midenup::try_parse_from(["midenup", "install", "0.15.0"])
@@ -178,7 +178,7 @@ fn integration_install_republishes_rather_than_mutating() {
     let _guard = common::harness::mutating_test_guard();
     let test_env = environment_setup("integration_install_republishes");
 
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
     let channel = semver::Version::new(0, 15, 0);
 
@@ -226,7 +226,7 @@ fn integration_var_survives_update_and_republication() {
     let _guard = common::harness::mutating_test_guard();
     let test_env = environment_setup("integration_var_survives");
 
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
     let channel = semver::Version::new(0, 15, 0);
 

--- a/tests/miden.rs
+++ b/tests/miden.rs
@@ -226,7 +226,7 @@ fn integration_midenup_catches_installation_failure() {
 fn integration_activation_unions_intent_across_projects() {
     let _guard = common::harness::mutating_test_guard();
     let test_env = environment_setup("integration_activation_unions_intent");
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
 
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
     let channel = semver::Version::new(0, 15, 0);
@@ -271,4 +271,42 @@ fn integration_activation_unions_intent_across_projects() {
         !state.get(&channel).unwrap().intent.roots.contains("assets"),
         "a direct install replaces intent, so it is allowed to shrink"
     );
+}
+
+/// Invoking `miden +channel ...` should override the toolchain selection
+#[test]
+fn integration_miden_explicit_toolchain_override() {
+    let _guard = common::harness::mutating_test_guard();
+    let test_env = environment_setup("integration_miden_explicit_toolchain_override");
+    let fixture = common::harness::OfflineFixture::new(test_env.tmp_dir.path())
+        .with_channel("0.15.0")
+        .with_channel("0.16.0")
+        .build();
+
+    let (mut state, mut config) = test_setup(&test_env, &fixture.manifest_uri);
+
+    let output_handle = config.capture_output();
+
+    // The default toolchain should be 0.15.0
+    {
+        let command = Midenup::try_parse_from(["miden", "help", "vm"]).unwrap();
+        command
+            .execute_with_state(&config, &mut state)
+            .expect("failed to execute command with toolchain override");
+        let mut output = output_handle.borrow_mut();
+        assert!(output.status.success());
+        let stdout = core::mem::take(&mut output.stdout);
+        output.stderr.clear();
+        assert_eq!(core::str::from_utf8(&stdout).unwrap(), "miden-vm 0.15.0\n");
+    }
+
+    // With an explicit override, we should be able to pick up 0.16.0 explicitly
+    let command = Midenup::try_parse_from(["miden", "+0.16.0", "help", "vm"]).unwrap();
+    command
+        .execute_with_state(&config, &mut state)
+        .expect("failed to execute command with toolchain override");
+
+    let output = output_handle.borrow();
+    assert!(output.status.success());
+    assert_eq!(core::str::from_utf8(&output.stdout).unwrap(), "miden-vm 0.16.0\n");
 }

--- a/tests/migrate.rs
+++ b/tests/migrate.rs
@@ -130,7 +130,7 @@ fn integration_uninstall_removes_the_publication_wholesale() {
     let _guard = common::harness::mutating_test_guard();
     let test_env = environment_setup("integration_uninstall_wholesale");
 
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
     let channel = semver::Version::new(0, 15, 0);
 

--- a/tests/networks.rs
+++ b/tests/networks.rs
@@ -15,7 +15,7 @@ use common::*;
 fn integration_networks_one_install_writes_every_naming_link() {
     let _guard = common::harness::mutating_test_guard();
     let test_env = environment_setup("integration_networks_shared");
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
 
     Midenup::try_parse_from(["midenup", "init"])
@@ -47,7 +47,7 @@ fn integration_networks_one_install_writes_every_naming_link() {
 fn integration_networks_stable_still_installs_mainnet() {
     let _guard = common::harness::mutating_test_guard();
     let test_env = environment_setup("integration_networks_synonym");
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
 
     Midenup::try_parse_from(["midenup", "init"])
@@ -516,7 +516,7 @@ fn integration_networks_update_leaves_other_networks_alone() {
 #[test]
 fn integration_networks_update_of_an_uninstalled_network_says_so() {
     let test_env = environment_setup("integration_networks_uninstalled");
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
 
     let err = Midenup::try_parse_from(["midenup", "update", "testnet"])
@@ -534,7 +534,7 @@ fn integration_networks_update_of_an_uninstalled_network_says_so() {
 #[test]
 fn integration_networks_update_of_an_unknown_network_lists_the_known_ones() {
     let test_env = environment_setup("integration_networks_unknown");
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
 
     let err = Midenup::try_parse_from(["midenup", "update", "mainet"])
@@ -549,7 +549,7 @@ fn integration_networks_update_of_an_unknown_network_lists_the_known_ones() {
 #[test]
 fn integration_networks_install_of_an_unknown_network_lists_the_known_ones() {
     let test_env = environment_setup("integration_networks_install_unknown_name");
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
 
     let err = Midenup::try_parse_from(["midenup", "install", "mainet"])
@@ -564,7 +564,7 @@ fn integration_networks_install_of_an_unknown_network_lists_the_known_ones() {
 #[test]
 fn integration_networks_install_of_an_unknown_version_names_that_version() {
     let test_env = environment_setup("integration_networks_install_unknown_version");
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
 
     let err = Midenup::try_parse_from(["midenup", "install", "9.9.9"])
@@ -581,7 +581,7 @@ fn integration_networks_install_of_an_unknown_version_names_that_version() {
 fn integration_networks_uninstall_removes_every_naming_link() {
     let _guard = common::harness::mutating_test_guard();
     let test_env = environment_setup("integration_networks_uninstall");
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
 
     for args in [
@@ -653,7 +653,7 @@ fn integration_networks_uninstall_does_not_leave_default_dangling() {
 
     for selector in ["mainnet", "0.15.0"] {
         let test_env = environment_setup("integration_networks_default");
-        let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+        let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
         let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
 
         for args in [
@@ -728,7 +728,7 @@ fn integration_networks_override_follows_the_network() {
 #[test]
 fn integration_networks_set_writes_the_canonical_name() {
     let test_env = environment_setup("integration_networks_set");
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
 
     Midenup::try_parse_from(["midenup", "set", "stable"])

--- a/tests/uninstall.rs
+++ b/tests/uninstall.rs
@@ -15,7 +15,7 @@ fn integration_uninstall_keeps_var_unless_purge_is_given() {
     let _guard = common::harness::mutating_test_guard();
     let test_env = environment_setup("integration_uninstall_var");
 
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
     let channel = semver::Version::new(0, 15, 0);
 
@@ -66,7 +66,7 @@ fn integration_uninstall_purges_the_store_of_the_selector_it_was_given() {
     let _guard = common::harness::mutating_test_guard();
     let test_env = environment_setup("integration_uninstall_purge_selector");
 
-    let fixture = common::harness::OfflineFixture::build(test_env.tmp_dir.path(), "0.15.0");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
     let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
 
     let var = test_env.midenup_home.join("var");


### PR DESCRIPTION
This PR implements support for `miden +channel CMD ...`, which explicitly overrides the toolchain for `CMD` to `channel`, regardless of what the global default is, and ignoring any local `miden-toolchain.toml` file that would otherwise apply.

I've also cleaned up the current 0.16.0 toolchain as follows:

* Removed `miden-ntx-builder` in favor of the node component itself providing that functionality
* Removed `cargo-miden`/`midenc` components until support for compressed artifacts is implemented