### PR TITLE
feat: support tar.gz artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +203,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +310,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +330,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -475,6 +510,7 @@ dependencies = [
  "colored",
  "curl",
  "dirs",
+ "flate2",
  "fs4",
  "heck",
  "petgraph",
@@ -483,11 +519,22 @@ dependencies = [
  "serde-untagged",
  "serde_json",
  "sha2",
+ "tar",
  "tempdir",
  "thiserror",
  "tiny_http",
  "toml 1.1.2+spec-1.1.0",
  "upon",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -735,6 +782,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -759,6 +812,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ clap.workspace = true
 colored.workspace = true
 curl = "0.4"
 dirs = "6.0"
+flate2 = { version = "1.1", default-features = false, features = ["rust_backend"] }
 # Advisory file locking (`flock`), for the $MIDENUP_HOME lock.
 fs4 = { version = "1.1", default-features = false, features = ["sync"] }
 heck = "0.5"
@@ -69,6 +70,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde-untagged = "0.1"
 sha2 = "0.11"
+tar = { version = "0.4", default-features = false }
 thiserror.workspace = true
 toml = { version = "1.0", features = ["preserve_order"] }
 upon = { version = "0.10", default-features = false, features = [

--- a/docs/src/design/manifest.md
+++ b/docs/src/design/manifest.md
@@ -108,11 +108,32 @@ Substitutions available in a URI are `%target`, `%version` (which requires a reg
 
 `digest` is **recorded and never verified**. It exists so that a future release can start checking it without a schema change; nothing today draws any conclusion from it, and nothing should claim otherwise.
 
+#### Compressed artifacts
+
+The artifact may be a compressed binary. In that case, the "archive" field defines the type of packaging used.
+
+
+```json
+"artifacts": {
+  "miden-vm": {
+    "uri": "https://github.com/0xMiden/miden-vm/releases/download/v%version/miden-vm-%target.tar.gz",
+    "archive": "tar.gz",
+    "targets": { "aarch64-apple-darwin": {}, "x86_64-unknown-linux-gnu": {} }
+  }
+}
+```
+
+Currently, `tar.gz` is the only format supported (more may be added later). A format not supported will cause an installation failure.
+
+The archive must hold exactly one file, which is the artifact; a file nested under a directory is fine. Several files is an error, so an archive shipping a README or a licence beside the binary cannot be used as-is.
+
+Nothing after acquisition changes: the artifact id is still the installed filename, and the destination, mode and receipt are what a bare file would get. Only that one file is written.
+
 ## Validation
 
 Validation is an authoring gate, not a parsing gate: `update-manifest check` runs the full structural validator, and plan construction re-checks what depends on the current target. Parsing deliberately does *not* validate — the published manifest has historically contained channels with dangling requirements, and refusing to parse would break every command for every user over a channel they were not using.
 
-The structural rules are platform-neutral: duplicate names, dangling or cyclic `requires`, unsafe artifact ids, destination collisions, alias conflicts, malformed digests, and the network rules described above. Target availability is checked only when an installation is actually planned.
+The structural rules are platform-neutral: duplicate names, dangling or cyclic `requires`, unsafe artifact ids, destination collisions, alias conflicts, malformed digests, archive formats midenup cannot read, `.tar.gz` URIs that forgot to declare `archive`, and the network rules described above. Target availability is checked only when an installation is actually planned.
 
 ## Custom manifests
 

--- a/docs/src/design/spec.md
+++ b/docs/src/design/spec.md
@@ -299,6 +299,31 @@ If a component is selected and any of its declared artifacts has no entry for th
 
 `digest` is optional, of the form `<algorithm>:<hex>`. It is validated for shape at parse time, recorded verbatim in the installation receipt when present, and round-trips losslessly. **No verification is performed currently.** Enabling verification later is a behavior change, not a schema change.
 
+For an archived artifact (§6.5) the digest describes the archive as fetched, not the file installed out of it: it belongs to the bytes at the URI.
+
+### 6.5 Archived artifacts
+
+An artifact may be published inside an archive. `archive` names the format:
+
+```json
+"artifacts": {
+  "miden-vm": {
+    "uri": "https://github.com/0xMiden/miden-vm/releases/download/v%version/%basename-%target.tar.gz",
+    "archive": "tar.gz",
+    "targets": {
+      "aarch64-apple-darwin":     { "basename": "miden-vm" },
+      "x86_64-unknown-linux-gnu": { "basename": "miden-vm" }
+    }
+  }
+}
+```
+
+- **Format:** `tar.gz`. Others are additive: a format is a variant plus a reader, and a manifest declaring one this build does not know would still parse (§4.4) and be rejected only when an installation is planned for it. The plan carries a format narrowed to the set this build reads (`SupportedFormat`), not the declared one, so the executor has no unsupported case to handle.
+- **The archive must hold exactly one file**, which is the artifact. Zero, or more than one, is an error; nothing is inferred from member names, and there is no way to select among several. Directory entries are skipped, so a file nested under one is found.
+- The object form `{ "format": "tar.gz" }` is also accepted, so a newer schema can add fields beside the format without an older `midenup` losing them (§4.4).
+
+An archive changes only how the bytes travel: the artifact id is still the installed filename, the destination and mode still come from §8, and the receipt records `prebuilt` like any other artifact. Extraction happens in memory and only that file is ever written.
+
 ---
 
 ## 7. Components
@@ -563,9 +588,10 @@ struct InstallationPlan {
 }
 
 enum PlanStep {
-    Download   { uri: ArtifactUri, dest: PathBuf, mode: u32,
-                 owner: ComponentName, digest: Option<Digest> },
-    CopyLocal  { src: PathBuf, dest: PathBuf, mode: u32, owner: ComponentName },
+    Download   { uri: ArtifactUri, dest: PathBuf, mode: u32, owner: ComponentName,
+                 digest: Option<Digest>, archive: Option<SupportedFormat> },
+    CopyLocal  { src: PathBuf, dest: PathBuf, mode: u32, owner: ComponentName,
+                 archive: Option<SupportedFormat> },
     CargoBuild { crate_name: String, authority: ResolvedAuthority, features: Vec<String>,
                  rustup_channel: Option<String>, expect_binary: String,
                  dest: PathBuf, owner: ComponentName },
@@ -595,9 +621,10 @@ Before the plan key is computed, every authority is pinned:
 1. Transfer to a unique temporary sibling of `dest` (`<dest>.<random>.part`), following at most 10 redirects.
 2. Check the HTTP status **after** the transfer completes and reject any non-2xx terminal response. Previously the install script read the response code early as 0, so 404/500 responses would be written to disk as if they succeeded.
 3. Reject an empty body.
-4. Apply the mode from the plan.
-5. `rename` into place.
-6. On any failure, remove the temporary file. If the owning component declares `prebuilt-with-cargo-fallback`, convert the step to `CargoBuild` and retry once; a successful fallback clears the failure.
+4. When the step carries an `archive` (§6.5), read the one file out of the transferred bytes and continue with that; the container itself is never written.
+5. Apply the mode from the plan.
+6. `rename` into place.
+7. On any failure, remove the temporary file. If the owning component declares `prebuilt-with-cargo-fallback`, convert the step to `CargoBuild` and retry once; a successful fallback clears the failure.
 
 For `https` sources the destination filename comes from the **plan**, never from the URL.
 
@@ -700,7 +727,9 @@ The protocol targets **process-crash consistency**: `fsync` on file contents bef
 plan_key = "pk1:" || hex(sha256(canonical_encoding(inputs)))
 ```
 
-**Included:** target triple; each selected component's name, resolved authority (with branches pinned to commits and paths to canonical path + mtime), kind, installation method, artifact IDs and resolved URIs, exact destinations, file modes, Cargo crate name / features / rustup channel, and the complete symlink layout.
+**Included:** target triple; each selected component's name, resolved authority (with branches pinned to commits and paths to canonical path + mtime), kind, installation method, artifact IDs and resolved URIs, the archive format of any archived artifact, exact destinations, file modes, Cargo crate name / features / rustup channel, and the complete symlink layout.
+
+The archive contribution is emitted only for an artifact that declares one, so an unarchived artifact encodes identically either way. That is the general rule for extending the encoding: a contribution emitted only for an input no manifest could express without it keeps every existing key byte-for-byte stable, so no installed component is reclassified as changed and the prefix stands; a contribution that alters an already-expressible input requires the prefix to change.
 
 **Excluded:** intent and profiles; aliases; call formats; `subcommands`; `initialization`; which networks name the channel; anything that does not change a byte on disk.
 
@@ -979,6 +1008,8 @@ The following are call disallowed and caught by validation:
 * the §7.7 matrix
 *  a `%target`-less URI in a target-specific artifact
 * malformed `digest`
+* an `archive` format this build cannot read
+* an artifact whose resolved URI ends in a known archive extension without declaring `archive`, which would install the container as the artifact - unless the artifact id carries that extension too, which asks for exactly that
 * `legacy-package` in a newly authored channel
 * a network naming a channel that is not in the document
 * a network with an empty name

--- a/docs/src/design/spec.md
+++ b/docs/src/design/spec.md
@@ -320,9 +320,10 @@ An artifact may be published inside an archive. `archive` names the format:
 
 - **Format:** `tar.gz`. Others are additive: a format is a variant plus a reader, and a manifest declaring one this build does not know would still parse (§4.4) and be rejected only when an installation is planned for it. The plan carries a format narrowed to the set this build reads (`SupportedFormat`), not the declared one, so the executor has no unsupported case to handle.
 - **The archive must hold exactly one file**, which is the artifact. Zero, or more than one, is an error; nothing is inferred from member names, and there is no way to select among several. Directory entries are skipped, so a file nested under one is found.
+- **The decompressed archive may be at most 2 GiB**, including format metadata and padding. Anything larger is rejected while it is being unpacked.
 - The object form `{ "format": "tar.gz" }` is also accepted, so a newer schema can add fields beside the format without an older `midenup` losing them (§4.4).
 
-An archive changes only how the bytes travel: the artifact id is still the installed filename, the destination and mode still come from §8, and the receipt records `prebuilt` like any other artifact. Extraction happens in memory and only that file is ever written.
+An archive changes only how the bytes travel: the artifact id is still the installed filename, the destination and mode still come from §8, and the receipt records `prebuilt` like any other artifact. The compressed source is held in memory while the decompressed archive is streamed. Its sole file is written to temporary storage and published only after the complete archive has been validated; the archive container itself is never written.
 
 ---
 

--- a/manifest/channel-manifest.json
+++ b/manifest/channel-manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": "3.0.0",
-  "date": 1786377658,
+  "date": 1786461825,
   "networks": {
     "devnet": "0.16.0",
     "mainnet": "0.15.0",
@@ -1771,6 +1771,44 @@
       "components": [
         {
           "aliases": {
+            "new": [
+              "cargo",
+              "miden",
+              "new"
+            ]
+          },
+          "artifacts": {
+            "cargo-miden": {
+              "archive": "tar.gz",
+              "targets": {
+                "aarch64-apple-darwin": {},
+                "x86_64-unknown-linux-gnu": {}
+              },
+              "uri": "https://github.com/0xMiden/compiler/releases/download/v%version/cargo-miden-%target.tar.gz"
+            }
+          },
+          "call-format": [
+            "cargo",
+            "miden"
+          ],
+          "hide": true,
+          "installation_method": {
+            "kind": "prebuilt"
+          },
+          "installed-executable": "cargo-miden",
+          "kind": "cargo-extension",
+          "name": "cargo-miden",
+          "profiles": [
+            "minimal"
+          ],
+          "symlink-name": "cargo-miden",
+          "version": {
+            "kind": "registry",
+            "version": "0.10.0-rc.1"
+          }
+        },
+        {
+          "aliases": {
             "account": [
               "%installed-executable",
               "new-account"
@@ -1901,6 +1939,46 @@
           "version": {
             "kind": "registry",
             "version": "0.16.0-alpha.1"
+          }
+        },
+        {
+          "aliases": {
+            "build": [
+              "%installed-executable"
+            ]
+          },
+          "artifacts": {
+            "midenc": {
+              "archive": "tar.gz",
+              "targets": {
+                "aarch64-apple-darwin": {},
+                "x86_64-unknown-linux-gnu": {}
+              },
+              "uri": "https://github.com/0xMiden/compiler/releases/download/v%version/midenc-%target.tar.gz"
+            }
+          },
+          "call-format": [
+            "%installed-executable",
+            "-L",
+            "%lib"
+          ],
+          "hide": false,
+          "installation_method": {
+            "kind": "prebuilt"
+          },
+          "installed-executable": "midenc",
+          "kind": "executable",
+          "name": "midenc",
+          "profiles": [
+            "minimal"
+          ],
+          "requires": [
+            "core",
+            "protocol"
+          ],
+          "version": {
+            "kind": "registry",
+            "version": "0.10.0-rc.1"
           }
         },
         {

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -520,6 +520,33 @@ pub enum ArtifactUri {
 }
 
 impl ArtifactUri {
+    /// What the artifact is fetched *from*, with everything that does not name it removed.
+    ///
+    /// For HTTP that is the URL's path: a server looks for `tool.tar.gz` when asked for
+    /// `https://host/tool.tar.gz?download=1`, and the authority is not part of what it looks for. A
+    /// `file://` source is a filesystem path, where `?` and `#` are ordinary characters and the
+    /// whole thing names the file.
+    ///
+    /// Anything reading a URI for what it points at wants this rather than the URI itself, which
+    /// carries decoration that reads like part of a name and is not.
+    pub fn path(&self) -> Cow<'_, str> {
+        match self {
+            Self::File(path) => path.to_string_lossy(),
+            Self::Http(uri) => {
+                // Whichever comes first: a fragment may contain a `?`, a query may contain a `#`.
+                let addressed = &uri[..uri.find(['?', '#']).unwrap_or(uri.len())];
+
+                // Past the authority, so a host that ends in an extension is not read as a path
+                // that does.
+                let path = match addressed.split_once("://") {
+                    Some((_, rest)) => rest.find('/').map_or("", |root| &rest[root..]),
+                    None => addressed,
+                };
+                Cow::Borrowed(path)
+            },
+        }
+    }
+
     pub fn file_name(&self) -> Option<&Path> {
         match self {
             Self::File(path) => path.file_name().map(Path::new),
@@ -862,6 +889,31 @@ mod archive_tests {
 
     fn parse(source: serde_json::Value) -> Artifact {
         serde_json::from_value(source).expect("must parse")
+    }
+
+    /// A URI carries decoration that reads like part of a name and is not: what is fetched is the
+    /// path, and only the path.
+    #[test]
+    fn a_uri_path_is_what_names_the_file() {
+        let cases = [
+            ("https://host/dir/vm.tar.gz", "/dir/vm.tar.gz"),
+            // Neither a query nor a fragment is fetched, and either may contain the other's mark.
+            ("https://host/vm.tar.gz?download=1", "/vm.tar.gz"),
+            ("https://host/vm.tar.gz#sha256?x", "/vm.tar.gz"),
+            ("https://host/vm.tar.gz?a=#b", "/vm.tar.gz"),
+            // A host is not fetched either, spelled like a file or not.
+            ("https://host.tar.gz/vm", "/vm"),
+            ("https://host.tar.gz", ""),
+        ];
+
+        for (uri, expected) in cases {
+            let parsed = ArtifactUri::Http(uri.to_string());
+            assert_eq!(parsed.path(), expected, "for {uri}");
+        }
+
+        // A local source is a path already: every character of it names the file.
+        let local = ArtifactUri::File(PathBuf::from("/releases/vm?1.tar.gz"));
+        assert_eq!(local.path(), "/releases/vm?1.tar.gz");
     }
 
     /// Every format this build reads must survive the manifest: declared by its spelling, it parses

--- a/src/artifact.rs
+++ b/src/artifact.rs
@@ -44,6 +44,179 @@ pub enum InvalidArtifactError {
         component: String,
         target: String,
     },
+    #[error(
+        "invalid artifact: artifact {id} of {component} is packaged as '{format}', which this \
+         version of midenup cannot read"
+    )]
+    UnsupportedArchiveFormat {
+        id: String,
+        component: String,
+        format: String,
+    },
+}
+
+/// How an artifact is packaged at its URI.
+///
+/// The archive must hold exactly one file, which is the artifact. An archive holding several is an
+/// error. An unsupported format would still parse; it is rejected when an installation is planned
+/// for it.
+#[derive(Debug, Clone, Hash, PartialEq)]
+pub struct Archive {
+    pub format: ArchiveFormat,
+    /// Fields declared by a newer schema that this build does not recognize.
+    pub extra: crate::manifest::v3::unknown::Extra,
+}
+
+/// The typed shape of an archive, without the unknown-field capture.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "kebab-case")]
+struct ArchiveFields {
+    format: ArchiveFormat,
+}
+
+/// Serialized as a bare format string when that is all it is, which is every archive this build
+/// declares itself.
+impl Serialize for Archive {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::Error;
+
+        if self.extra.is_empty() {
+            return self.format.serialize(serializer);
+        }
+        crate::manifest::v3::unknown::merge_extra(
+            &ArchiveFields { format: self.format.clone() },
+            &self.extra,
+        )
+        .map_err(S::Error::custom)?
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Archive {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::Error;
+
+        let value = serde_json::Value::deserialize(deserializer)?;
+
+        // The shape every archive needs today; the object form exists so a newer schema can add
+        // fields beside the format without this build losing them.
+        if let serde_json::Value::String(format) = value {
+            return Ok(Self {
+                format: ArchiveFormat::parse(&format),
+                extra: Default::default(),
+            });
+        }
+
+        let (fields, extra) = crate::manifest::v3::unknown::split_extra::<ArchiveFields>(value)
+            .map_err(D::Error::custom)?;
+        Ok(Self { format: fields.format, extra })
+    }
+}
+
+/// A format this build has a reader for.
+///
+/// Constructible only by [ArchiveFormat::supported], so an unsupported format cannot be expressed
+/// past resolution: the plan and the executor take this type, and therefore have no unsupported
+/// case to handle.
+///
+/// Adding a format is a variant here, an entry in [SupportedFormat::ALL], an arm in
+/// [SupportedFormat::as_str], and a reader in [crate::install::archive].
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub enum SupportedFormat {
+    /// A gzip-compressed tar archive.
+    TarGz,
+}
+
+impl SupportedFormat {
+    /// Every format this build can read. The sole table: parsing, validation and the round-trip
+    /// test all derive from it.
+    pub const ALL: &'static [Self] = &[Self::TarGz];
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::TarGz => "tar.gz",
+        }
+    }
+}
+
+impl fmt::Display for SupportedFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The format an artifact declares itself packaged in, supported by this build or not.
+///
+/// This is the wire type: it is what a manifest can say, which is not the same as what this build
+/// can do. [ArchiveFormat::supported] is the one way across that gap.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum ArchiveFormat {
+    /// A format this build can read.
+    Supported(SupportedFormat),
+    /// A format this build cannot read. Recorded verbatim so it round-trips; rejected before an
+    /// installation is planned for it.
+    Unsupported(String),
+}
+
+impl ArchiveFormat {
+    /// Interprets a declared spelling. An unrecognized one is a value, not a failure: see
+    /// [Archive].
+    pub fn parse(spelling: &str) -> Self {
+        match SupportedFormat::ALL.iter().find(|format| format.as_str() == spelling) {
+            Some(format) => Self::Supported(*format),
+            None => Self::Unsupported(spelling.to_string()),
+        }
+    }
+
+    /// The reader for this format, if this build has one.
+    pub fn supported(&self) -> Option<SupportedFormat> {
+        match self {
+            Self::Supported(format) => Some(*format),
+            Self::Unsupported(_) => None,
+        }
+    }
+
+    pub fn is_supported(&self) -> bool {
+        self.supported().is_some()
+    }
+
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Supported(format) => format.as_str(),
+            Self::Unsupported(spelling) => spelling,
+        }
+    }
+
+    /// Every spelling an author may write.
+    pub fn supported_spellings() -> impl Iterator<Item = &'static str> {
+        SupportedFormat::ALL.iter().map(SupportedFormat::as_str)
+    }
+}
+
+impl fmt::Display for ArchiveFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Serialize for ArchiveFormat {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for ArchiveFormat {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self::parse(&String::deserialize(deserializer)?))
+    }
+}
+
+/// An artifact resolved for one target: where to fetch it, and what it is packaged as.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedArtifact {
+    pub uri: ArtifactUri,
+    /// Present when the fetched bytes are an archive rather than the file itself.
+    pub archive: Option<SupportedFormat>,
 }
 
 /// All the artifacts that the [Component] contains.
@@ -62,7 +235,7 @@ impl Artifacts {
         self.artifacts.insert(id, artifact).is_none()
     }
 
-    /// Returns the `(artifact id, uri)` pairs that should be installed for `target`.
+    /// Returns the `(artifact id, resolved artifact)` pairs that should be installed for `target`.
     ///
     /// The artifact id is the exact filename the artifact is installed as, so callers must use it
     /// to compute a destination path rather than inferring one from the URI.
@@ -70,13 +243,13 @@ impl Artifacts {
         &'a self,
         target: &str,
         component: &'a Component,
-    ) -> Result<Vec<(&'a str, ArtifactUri)>, InvalidArtifactError> {
+    ) -> Result<Vec<(&'a str, ResolvedArtifact)>, InvalidArtifactError> {
         match component.kind() {
             ComponentKind::Asset => self.get_artifacts_for_target(target, component),
             ComponentKind::CargoExtension { spec, .. } | ComponentKind::Executable { spec, .. } => {
                 let id = spec.installed_executable.as_str();
                 let artifact = self.get_artifact_for_target(id, target, component)?;
-                Ok(artifact.into_iter().map(|uri| (id, uri)).collect())
+                Ok(artifact.into_iter().map(|resolved| (id, resolved)).collect())
             },
             // Never selected for installation, so it has no artifacts to resolve. The resolver
             // is the gate that rejects it; this arm just keeps the match total.
@@ -87,16 +260,16 @@ impl Artifacts {
         }
     }
 
-    /// Returns every declared `(artifact id, uri)` pair available for `target`.
+    /// Returns every declared `(artifact id, resolved artifact)` pair available for `target`.
     pub fn get_artifacts_for_target(
         &self,
         target: &str,
         component: &Component,
-    ) -> Result<Vec<(&str, ArtifactUri)>, InvalidArtifactError> {
+    ) -> Result<Vec<(&str, ResolvedArtifact)>, InvalidArtifactError> {
         let mut artifacts = Vec::with_capacity(self.artifacts.len());
         for (id, artifact) in self.artifacts.iter() {
-            if let Some(uri) = artifact.get_uri_for(id, target, component)? {
-                artifacts.push((id.as_str(), uri));
+            if let Some(resolved) = artifact.resolve_for(id, target, component)? {
+                artifacts.push((id.as_str(), resolved));
             }
         }
 
@@ -108,11 +281,11 @@ impl Artifacts {
         id: &str,
         target: &str,
         component: &Component,
-    ) -> Result<Option<ArtifactUri>, InvalidArtifactError> {
+    ) -> Result<Option<ResolvedArtifact>, InvalidArtifactError> {
         let Some(artifact) = self.artifacts.get(id) else {
             return Ok(None);
         };
-        artifact.get_uri_for(id, target, component)
+        artifact.resolve_for(id, target, component)
     }
 }
 
@@ -167,6 +340,8 @@ pub enum Artifact {
         targets: BTreeMap<String, Substitutions>,
         /// An optional content digest. Recorded and round-tripped, never verified. See [Digest].
         digest: Option<Digest>,
+        /// How the artifact is packaged at that URI, if it is not the bare file. See [Archive].
+        archive: Option<Archive>,
         /// Fields declared by a newer schema that this build does not recognize.
         extra: crate::manifest::v3::unknown::Extra,
     },
@@ -180,6 +355,8 @@ pub enum Artifact {
         uri: String,
         /// An optional content digest. Recorded and round-tripped, never verified. See [Digest].
         digest: Option<Digest>,
+        /// How the artifact is packaged at that URI, if it is not the bare file. See [Archive].
+        archive: Option<Archive>,
         /// Fields declared by a newer schema that this build does not recognize.
         extra: crate::manifest::v3::unknown::Extra,
     },
@@ -199,27 +376,39 @@ enum ArtifactFields {
         targets: BTreeMap<String, Substitutions>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         digest: Option<Digest>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        archive: Option<Archive>,
     },
     TargetAgnostic {
         uri: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         digest: Option<Digest>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        archive: Option<Archive>,
     },
 }
 
 impl Artifact {
     fn fields(&self) -> ArtifactFields {
         match self {
-            Self::TargetSpecific { uri, substitutions, targets, digest, .. } => {
-                ArtifactFields::TargetSpecific {
-                    uri: uri.clone(),
-                    substitutions: substitutions.clone(),
-                    targets: targets.clone(),
-                    digest: digest.clone(),
-                }
+            Self::TargetSpecific {
+                uri,
+                substitutions,
+                targets,
+                digest,
+                archive,
+                ..
+            } => ArtifactFields::TargetSpecific {
+                uri: uri.clone(),
+                substitutions: substitutions.clone(),
+                targets: targets.clone(),
+                digest: digest.clone(),
+                archive: archive.clone(),
             },
-            Self::TargetAgnostic { uri, digest, .. } => {
-                ArtifactFields::TargetAgnostic { uri: uri.clone(), digest: digest.clone() }
+            Self::TargetAgnostic { uri, digest, archive, .. } => ArtifactFields::TargetAgnostic {
+                uri: uri.clone(),
+                digest: digest.clone(),
+                archive: archive.clone(),
             },
         }
     }
@@ -260,17 +449,22 @@ impl<'de> Deserialize<'de> for Artifact {
             .map_err(D::Error::custom)?;
 
         Ok(match fields {
-            ArtifactFields::TargetSpecific { uri, substitutions, targets, digest } => {
-                Self::TargetSpecific {
-                    uri,
-                    substitutions,
-                    targets,
-                    digest,
-                    extra,
-                }
+            ArtifactFields::TargetSpecific {
+                uri,
+                substitutions,
+                targets,
+                digest,
+                archive,
+            } => Self::TargetSpecific {
+                uri,
+                substitutions,
+                targets,
+                digest,
+                archive,
+                extra,
             },
-            ArtifactFields::TargetAgnostic { uri, digest } => {
-                Self::TargetAgnostic { uri, digest, extra }
+            ArtifactFields::TargetAgnostic { uri, digest, archive } => {
+                Self::TargetAgnostic { uri, digest, archive, extra }
             },
         })
     }
@@ -278,10 +472,22 @@ impl<'de> Deserialize<'de> for Artifact {
 
 impl Artifact {
     /// The declared content digest, if any. Never verified -- see [Digest].
+    ///
+    /// For an archived artifact it describes the archive as fetched, not the file installed out of
+    /// it.
     pub fn digest(&self) -> Option<&Digest> {
         match self {
             Self::TargetSpecific { digest, .. } | Self::TargetAgnostic { digest, .. } => {
                 digest.as_ref()
+            },
+        }
+    }
+
+    /// How the artifact is packaged at its URI, if it is not the bare file.
+    pub fn archive(&self) -> Option<&Archive> {
+        match self {
+            Self::TargetSpecific { archive, .. } | Self::TargetAgnostic { archive, .. } => {
+                archive.as_ref()
             },
         }
     }
@@ -343,14 +549,14 @@ impl Artifact {
         let mut artifacts = vec![];
         match self {
             Self::TargetAgnostic { .. } => {
-                if let Some(artifact) = self.get_uri_for(id, "", component)? {
-                    artifacts.push(artifact);
+                if let Some(artifact) = self.resolve_for(id, "", component)? {
+                    artifacts.push(artifact.uri);
                 }
             },
             Self::TargetSpecific { targets, .. } => {
                 for target in targets.keys() {
-                    if let Some(artifact) = self.get_uri_for(id, target, component)? {
-                        artifacts.push(artifact);
+                    if let Some(artifact) = self.resolve_for(id, target, component)? {
+                        artifacts.push(artifact.uri);
                     }
                 }
             },
@@ -359,16 +565,15 @@ impl Artifact {
         Ok(artifacts)
     }
 
-    /// Returns the URI for the specified target, with the provided component details for use in
-    /// substitution patterns:
-    pub fn get_uri_for(
+    /// Resolves the artifact for `target`: its URI, and what it is packaged as.
+    pub fn resolve_for(
         &self,
         id: &str,
         target: &str,
         component: &Component,
-    ) -> Result<Option<ArtifactUri>, InvalidArtifactError> {
+    ) -> Result<Option<ResolvedArtifact>, InvalidArtifactError> {
         match self {
-            Self::TargetAgnostic { uri, .. } => {
+            Self::TargetAgnostic { uri, archive, .. } => {
                 let Some((scheme, rest)) = uri.split_once("://") else {
                     return Err(InvalidArtifactError::MissingScheme {
                         id: id.to_string(),
@@ -386,9 +591,16 @@ impl Artifact {
                 } else {
                     Cow::Borrowed(rest)
                 };
+                let archive = supported_archive(archive.as_ref(), id, component)?;
                 match scheme {
-                    "file" => Ok(Some(ArtifactUri::File(PathBuf::from(rest.into_owned())))),
-                    "http" | "https" => Ok(Some(ArtifactUri::Http(format!("{scheme}://{rest}")))),
+                    "file" => Ok(Some(ResolvedArtifact {
+                        uri: ArtifactUri::File(PathBuf::from(rest.into_owned())),
+                        archive,
+                    })),
+                    "http" | "https" => Ok(Some(ResolvedArtifact {
+                        uri: ArtifactUri::Http(format!("{scheme}://{rest}")),
+                        archive,
+                    })),
                     scheme => Err(InvalidArtifactError::InvalidScheme {
                         id: id.to_string(),
                         component: component.name.to_string(),
@@ -396,7 +608,7 @@ impl Artifact {
                     }),
                 }
             },
-            Self::TargetSpecific { uri, substitutions, targets, .. } => {
+            Self::TargetSpecific { uri, substitutions, targets, archive, .. } => {
                 let Some(target_subs) = targets.get(target) else {
                     return Ok(None);
                 };
@@ -446,9 +658,16 @@ impl Artifact {
                     rest
                 };
                 let rest = rest.replace("%basename", basename);
+                let archive = supported_archive(archive.as_ref(), id, component)?;
                 match scheme {
-                    "file" => Ok(Some(ArtifactUri::File(PathBuf::from(rest)))),
-                    "http" | "https" => Ok(Some(ArtifactUri::Http(format!("{scheme}://{rest}")))),
+                    "file" => Ok(Some(ResolvedArtifact {
+                        uri: ArtifactUri::File(PathBuf::from(rest)),
+                        archive,
+                    })),
+                    "http" | "https" => Ok(Some(ResolvedArtifact {
+                        uri: ArtifactUri::Http(format!("{scheme}://{rest}")),
+                        archive,
+                    })),
                     scheme => Err(InvalidArtifactError::InvalidScheme {
                         id: id.to_string(),
                         component: component.name.to_string(),
@@ -458,6 +677,27 @@ impl Artifact {
             },
         }
     }
+}
+
+/// Narrows a declared format to one this build can read, rejecting the rest.
+///
+/// Here rather than at execution because it is a fact about the manifest -- known before a single
+/// byte is fetched.
+fn supported_archive(
+    archive: Option<&Archive>,
+    id: &str,
+    component: &Component,
+) -> Result<Option<SupportedFormat>, InvalidArtifactError> {
+    let Some(archive) = archive else {
+        return Ok(None);
+    };
+    archive.format.supported().map(Some).ok_or_else(|| {
+        InvalidArtifactError::UnsupportedArchiveFormat {
+            id: id.to_string(),
+            component: component.name.to_string(),
+            format: archive.format.to_string(),
+        }
+    })
 }
 
 /// A content digest declared for an artifact, e.g. `sha256:9f86d081...`.
@@ -591,6 +831,114 @@ mod digest_tests {
 }
 
 #[cfg(test)]
+mod archive_tests {
+    use std::borrow::Cow;
+
+    use super::*;
+    use crate::{
+        manifest::{ComponentKind, ExecutableComponent, InstallationMethod},
+        profile::Profile,
+    };
+
+    const TARGET: &str = "aarch64-apple-darwin";
+
+    fn component() -> Component {
+        Component {
+            name: Cow::Borrowed("vm"),
+            version: Authority::Registry { version: semver::Version::new(0, 16, 0) },
+            kind: ComponentKind::Executable {
+                installation_method: InstallationMethod::Prebuilt,
+                spec: ExecutableComponent {
+                    installed_executable: "miden-vm".to_string(),
+                    ..Default::default()
+                },
+            },
+            profiles: vec![Profile::Minimal],
+            requires: vec![],
+            artifacts: Artifacts::default(),
+            extra: Default::default(),
+        }
+    }
+
+    fn parse(source: serde_json::Value) -> Artifact {
+        serde_json::from_value(source).expect("must parse")
+    }
+
+    /// Every format this build reads must survive the manifest: declared by its spelling, it parses
+    /// to that format and serializes back to the same document.
+    #[test]
+    fn every_supported_format_round_trips() {
+        for format in SupportedFormat::ALL {
+            let source = serde_json::json!({
+                "uri": "https://example.invalid/vm.tar.gz",
+                "archive": format.as_str()
+            });
+            let artifact = parse(source.clone());
+            assert_eq!(
+                artifact.archive().unwrap().format.supported(),
+                Some(*format),
+                "'{format}' must parse back to itself"
+            );
+            assert_eq!(serde_json::to_value(&artifact).unwrap(), source);
+        }
+    }
+
+    #[test]
+    fn an_archived_artifact_resolves_to_its_format() {
+        let artifact = parse(serde_json::json!({
+            "uri": "https://example.invalid/v%version/%basename-%target.%extension",
+            "archive": "tar.gz",
+            "basename": "miden-vm",
+            "extension": "tar.gz",
+            "targets": {TARGET: {}}
+        }));
+
+        let resolved = artifact
+            .resolve_for("miden-vm", TARGET, &component())
+            .expect("must resolve")
+            .expect("the target is declared");
+
+        assert_eq!(
+            resolved.uri.to_string(),
+            format!("https://example.invalid/v0.16.0/miden-vm-{TARGET}.tar.gz")
+        );
+        assert_eq!(resolved.archive, Some(SupportedFormat::TarGz));
+    }
+
+    /// An unreadable container is rejected when the installation is planned, not when the manifest
+    /// is parsed -- an unrelated channel must stay parseable.
+    #[test]
+    fn an_unreadable_format_parses_but_does_not_resolve() {
+        let source = serde_json::json!({
+            "uri": "https://example.invalid/vm.zip",
+            "archive": "zip"
+        });
+        let artifact = parse(source.clone());
+        assert_eq!(
+            serde_json::to_value(&artifact).unwrap(),
+            source,
+            "an unknown format must round-trip verbatim"
+        );
+
+        let err = artifact.resolve_for("miden-vm", "", &component()).expect_err("must fail");
+        assert!(matches!(err, InvalidArtifactError::UnsupportedArchiveFormat { .. }), "{err}");
+        assert!(err.to_string().contains("zip"), "the message must name the format: {err}");
+    }
+
+    /// An unarchived artifact emits no `archive` key at all, so existing manifests are untouched.
+    #[test]
+    fn an_unarchived_artifact_has_no_archive() {
+        let source = serde_json::json!({"uri": "https://example.invalid/core.masp"});
+        let artifact = parse(source.clone());
+        assert!(artifact.archive().is_none());
+        assert_eq!(serde_json::to_value(&artifact).unwrap(), source);
+
+        let resolved = artifact.resolve_for("core.masp", "", &component()).unwrap().unwrap();
+        assert!(resolved.archive.is_none());
+    }
+}
+
+#[cfg(test)]
 mod forward_compatibility_tests {
     use super::*;
 
@@ -625,6 +973,7 @@ mod forward_compatibility_tests {
             "uri": "https://example.invalid/%target.%extension",
             "basename": "miden-vm",
             "extension": "tar.gz",
+            "archive": "tar.gz",
             "targets": {"aarch64-apple-darwin": {}}
         });
 
@@ -634,10 +983,23 @@ mod forward_compatibility_tests {
         assert_eq!(out, source);
         assert_eq!(
             out.as_object().unwrap().len(),
-            4,
+            5,
             "no key may appear twice: {}",
             serde_json::to_string(&out).unwrap()
         );
+    }
+
+    /// The artifact's own capture only sees the top level, so a nested archive has to preserve its
+    /// unknown fields itself.
+    #[test]
+    fn unknown_fields_inside_an_archive_round_trip() {
+        let source = serde_json::json!({
+            "uri": "https://example.invalid/vm.tar.gz",
+            "archive": {"format": "tar.gz", "strip-components": 1}
+        });
+
+        let artifact: Artifact = serde_json::from_value(source.clone()).expect("must parse");
+        assert_eq!(serde_json::to_value(&artifact).unwrap(), source);
     }
 
     /// A malformed artifact names what is wrong with it, rather than reporting that no variant

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -615,6 +615,7 @@ mod tests {
             Artifact::TargetAgnostic {
                 uri: "https://example.invalid/v1/miden-vm".to_string(),
                 digest: None,
+                archive: None,
                 extra: Default::default(),
             },
         );
@@ -662,6 +663,7 @@ mod tests {
             Artifact::TargetAgnostic {
                 uri: "https://example.invalid/v2/miden-vm".to_string(),
                 digest: None,
+                archive: None,
                 extra: Default::default(),
             },
         );

--- a/src/install/archive.rs
+++ b/src/install/archive.rs
@@ -63,7 +63,7 @@ fn extract_bounded(
     // One past the limit, so that running out of allowance is distinguishable from a stream that
     // ended on it.
     let mut stream = match format {
-        SupportedFormat::TarGz => flate2::read::GzDecoder::new(body).take(limit + 1),
+        SupportedFormat::TarGz => flate2::read::MultiGzDecoder::new(body).take(limit + 1),
     };
 
     let result = from_tar(&mut stream, uri, out);
@@ -91,6 +91,10 @@ fn from_tar<R: Read>(stream: R, uri: &str, out: &mut impl Write) -> Result<(), A
     };
 
     let mut tar = tar::Archive::new(stream);
+    // A tar end marker is allowed to be followed by more tar data. Continue past zero blocks so a
+    // concatenated archive cannot hide a second file, and so arbitrary trailing payload is parsed
+    // and rejected rather than silently discarded below.
+    tar.set_ignore_zeros(true);
     let entries = tar.entries().map_err(malformed)?;
 
     // A flag rather than the bytes: the file is gone once written out, and a decompressing stream
@@ -127,8 +131,9 @@ fn from_tar<R: Read>(stream: R, uri: &str, out: &mut impl Write) -> Result<(), A
         }
     }
 
-    // Read for the errors it raises rather than for the bytes: whatever follows the tar is the
-    // stream's own bookkeeping, and there is nothing left to hand back a decoded byte to.
+    // Read for the errors it raises rather than for the bytes. Ignoring zero blocks normally makes
+    // the entry iterator reach EOF itself, but keep this drain as the format reader's explicit
+    // guarantee that a decompressor in front of it validates every trailer before success.
     let mut rest = tar.into_inner();
     std::io::copy(&mut rest, &mut std::io::sink()).map_err(malformed)?;
 
@@ -162,8 +167,8 @@ mod tests {
         extract_bounded(body, SupportedFormat::TarGz, URI, &mut out, limit).map(|()| out)
     }
 
-    /// A gzipped tar archive of `(path, contents)` entries.
-    fn tarball(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    /// A tar archive of `(path, contents)` entries.
+    fn tar(entries: &[(&str, &[u8])]) -> Vec<u8> {
         let mut tar = tar::Builder::new(Vec::new());
         for (path, contents) in entries {
             let mut header = tar::Header::new_gnu();
@@ -172,7 +177,12 @@ mod tests {
             header.set_cksum();
             tar.append_data(&mut header, path, *contents).unwrap();
         }
-        gzipped(tar.into_inner().unwrap())
+        tar.into_inner().unwrap()
+    }
+
+    /// A gzipped tar archive of `(path, contents)` entries.
+    fn tarball(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        gzipped(tar(entries))
     }
 
     fn gzipped(plain: Vec<u8>) -> Vec<u8> {
@@ -230,6 +240,16 @@ mod tests {
         assert!(err.to_string().contains(URI), "the message must name the source: {err}");
     }
 
+    /// End markers separate concatenated tar archives but do not make later files disappear.
+    #[test]
+    fn files_after_a_tar_end_marker_are_still_counted() {
+        let mut joined = tar(&[("a", b"one")]);
+        joined.extend(tar(&[("b", b"two")]));
+
+        let err = extracted(&gzipped(joined)).expect_err("must fail");
+        assert!(matches!(err, ArchiveError::NonZeroFiles { .. }), "{err}");
+    }
+
     #[test]
     fn an_archive_with_no_files_is_an_error() {
         let mut tar = tar::Builder::new(Vec::new());
@@ -256,6 +276,21 @@ mod tests {
     #[test]
     fn a_gzip_checksum_that_does_not_match_is_an_error() {
         let mut body = nested();
+        let crc = body.len() - TRAILER;
+        body[crc] ^= 0xff;
+
+        let err = extracted(&body).expect_err("must fail");
+        assert!(matches!(err, ArchiveError::Malformed { .. }), "{err}");
+    }
+
+    /// Every member belongs to the fetched gzip stream, so every trailer must be valid.
+    #[test]
+    fn a_later_gzip_member_checksum_must_match() {
+        let mut body = nested();
+        // Zero blocks are valid tar padding, ensuring the tar reader reaches the member's trailer.
+        body.extend(gzipped(vec![0; 1024]));
+        assert_eq!(extracted(&body).expect("every valid member should be accepted"), b"binary");
+
         let crc = body.len() - TRAILER;
         body[crc] ^= 0xff;
 
@@ -314,7 +349,7 @@ mod tests {
     fn an_archive_that_ends_on_the_limit_is_accepted() {
         let body = tarball(&[("snug", b"contents")]);
         let mut plain = Vec::new();
-        flate2::read::GzDecoder::new(&body[..]).read_to_end(&mut plain).unwrap();
+        flate2::read::MultiGzDecoder::new(&body[..]).read_to_end(&mut plain).unwrap();
 
         let extracted = extracted_under(plain.len() as u64, &body)
             .expect("a stream exactly the limit's length must be read");

--- a/src/install/archive.rs
+++ b/src/install/archive.rs
@@ -6,8 +6,8 @@
 //! # Adding a new supported format
 //!
 //! A reader beside [from_tar], and an arm for it in [file]. A reader takes a stream, so any
-//! decompression composes in front of it; one needing random access -- a zip's central directory
-//! sits at the end -- can take the whole body instead.
+//! decompression composes in front of it, and owes that stream a read through to EOF; one needing
+//! random access -- a zip's central directory sits at the end -- can take the whole body instead.
 
 use std::io::Read;
 
@@ -71,6 +71,14 @@ fn from_tar<R: Read>(stream: R, uri: &str) -> Result<Vec<u8>, ArchiveError> {
         only = Some(body);
     }
 
+    // Read for the errors it raises rather than for the bytes: whatever follows the tar is the
+    // stream's own bookkeeping, and there is nothing left to hand back a decoded byte to.
+    let mut rest = tar.into_inner();
+    std::io::copy(&mut rest, &mut std::io::sink()).map_err(|err| ArchiveError::Malformed {
+        uri: uri.to_string(),
+        reason: err.to_string(),
+    })?;
+
     only.ok_or_else(|| ArchiveError::Empty { uri: uri.to_string() })
 }
 
@@ -83,6 +91,9 @@ mod tests {
     use super::*;
 
     const URI: &str = "https://example.invalid/artifact.tar.gz";
+
+    /// A gzip stream ends with a CRC32 of the decompressed bytes and their length, four bytes each.
+    const TRAILER: usize = 8;
 
     /// A gzipped tar archive of `(path, contents)` entries.
     fn tarball(entries: &[(&str, &[u8])]) -> Vec<u8> {
@@ -152,6 +163,30 @@ mod tests {
         let err = file(&gzipped(tar.into_inner().unwrap()), SupportedFormat::TarGz, URI)
             .expect_err("must fail");
         assert!(matches!(err, ArchiveError::Empty { .. }), "{err}");
+    }
+
+    /// The tar inside is intact, so only reading the stream to its end catches this. `gzip -t`
+    /// rejects the same bytes.
+    #[test]
+    fn a_missing_gzip_trailer_is_an_error() {
+        let mut body = nested();
+        body.truncate(body.len() - TRAILER);
+
+        let err = file(&body, SupportedFormat::TarGz, URI).expect_err("must fail");
+        assert!(matches!(err, ArchiveError::Malformed { .. }), "{err}");
+        assert!(err.to_string().contains(URI), "the message must name the source: {err}");
+    }
+
+    /// An archive edited after the fact: the trailer is there and disagrees with the bytes that
+    /// came out of it.
+    #[test]
+    fn a_gzip_checksum_that_does_not_match_is_an_error() {
+        let mut body = nested();
+        let crc = body.len() - TRAILER;
+        body[crc] ^= 0xff;
+
+        let err = file(&body, SupportedFormat::TarGz, URI).expect_err("must fail");
+        assert!(matches!(err, ArchiveError::Malformed { .. }), "{err}");
     }
 
     /// Not an archive at all -- an HTML error page served with a 200, say.

--- a/src/install/archive.rs
+++ b/src/install/archive.rs
@@ -1,17 +1,23 @@
 //! Getting the file out of an archived artifact.
 //!
 //! An artifact is exactly one installed file (spec section 6.1), so the archive must hold exactly
-//! one file. Everything happens in memory: nothing but the artifact is written anywhere.
+//! one file. That file is streamed to a writer the caller owns rather than returned as bytes: a
+//! release binary runs to hundreds of megabytes, and the compressed body it comes out of is still
+//! in hand while it is being unpacked. Nothing but the artifact is written anywhere.
 //!
 //! # Adding a new supported format
 //!
-//! A reader beside [from_tar], and an arm for it in [file]. A reader takes a stream, so any
+//! A reader beside [from_tar], and an arm for it in [extract]. A reader takes a stream, so any
 //! decompression composes in front of it, and owes that stream a read through to EOF; one needing
 //! random access -- a zip's central directory sits at the end -- can take the whole body instead.
+//! The size limit lives in [extract], where it bounds every byte any reader pulls.
 
-use std::io::Read;
+use std::io::{Read, Write};
 
 use crate::artifact::SupportedFormat;
+
+/// 2 GB limit on decompressed archive size.
+const MAX_UNPACKED_BYTES: u64 = 2 * 1024 * 1024 * 1024;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ArchiveError {
@@ -21,37 +27,80 @@ pub enum ArchiveError {
     NonZeroFiles { uri: String },
     #[error("the archive fetched from '{uri}' contains no files at all")]
     Empty { uri: String },
+    #[error("the archive fetched from '{uri}' unpacks to more than {limit} bytes")]
+    TooLarge { uri: String, limit: u64 },
+    #[error("failed to write the file unpacked from '{uri}': {reason}")]
+    Unwritable { uri: String, reason: String },
 }
 
-/// Reads the one file `body` holds, as packaged by `format`.
+/// Writes the one file `body` holds, as packaged by `format`, to `out`.
 ///
 /// Every format has a reader by construction: [SupportedFormat] is exactly the set this build can
 /// read, so there is no unreadable case to report from here.
 ///
 /// `uri` is only used to say what failed: the bytes are already in hand.
-pub fn file(body: &[u8], format: SupportedFormat, uri: &str) -> Result<Vec<u8>, ArchiveError> {
-    match format {
-        SupportedFormat::TarGz => from_tar(flate2::read::GzDecoder::new(body), uri),
-    }
+///
+/// A failure can leave `out` written to: the file is streamed out before the trailer proving the
+/// archive intact has been read, and a second file only turns up after the first has been handed
+/// over. What arrived is the artifact when this returns `Ok`, and is to be discarded otherwise.
+pub fn extract(
+    body: &[u8],
+    format: SupportedFormat,
+    uri: &str,
+    out: &mut impl Write,
+) -> Result<(), ArchiveError> {
+    extract_bounded(body, format, uri, out, MAX_UNPACKED_BYTES)
 }
 
-/// Reads the sole regular file out of a tar stream.
-fn from_tar<R: Read>(stream: R, uri: &str) -> Result<Vec<u8>, ArchiveError> {
-    let mut tar = tar::Archive::new(stream);
-    let entries = tar.entries().map_err(|err| ArchiveError::Malformed {
+/// [extract], against a stated `limit`.
+fn extract_bounded(
+    body: &[u8],
+    format: SupportedFormat,
+    uri: &str,
+    out: &mut impl Write,
+    limit: u64,
+) -> Result<(), ArchiveError> {
+    // One past the limit, so that running out of allowance is distinguishable from a stream that
+    // ended on it.
+    let mut stream = match format {
+        SupportedFormat::TarGz => flate2::read::GzDecoder::new(body).take(limit + 1),
+    };
+
+    let result = from_tar(&mut stream, uri, out);
+
+    // Ahead of `result`: a stream cut off at the limit reaches the format reader as one that ended,
+    // which it may well accept, and a corrupt archive is the wrong thing to report about an archive
+    // that is merely too big.
+    if stream.limit() == 0 {
+        return Err(ArchiveError::TooLarge { uri: uri.to_string(), limit });
+    }
+
+    result
+}
+
+/// Streams the sole regular file out of a tar stream to `out`.
+///
+/// The stream is read through to EOF even once the tar data is accounted for, because a
+/// decompressor in front of it only verifies its checksum and length trailer when a read pushes
+/// past the compressed data, and the tar end-of-archive blocks come first. Stopping at the end of
+/// the tar takes a truncated or tampered archive for an intact one.
+fn from_tar<R: Read>(stream: R, uri: &str, out: &mut impl Write) -> Result<(), ArchiveError> {
+    let malformed = |err: std::io::Error| ArchiveError::Malformed {
         uri: uri.to_string(),
         reason: err.to_string(),
-    })?;
+    };
 
-    // Held as bytes rather than as a position, because a decompressing stream cannot be rewound to
-    // come back for it.
-    let mut only: Option<Vec<u8>> = None;
+    let mut tar = tar::Archive::new(stream);
+    let entries = tar.entries().map_err(malformed)?;
+
+    // A flag rather than the bytes: the file is gone once written out, and a decompressing stream
+    // cannot be rewound to come back for it.
+    let mut found = false;
+    // 64 KiB sized buffer.
+    let mut buffer = [0u8; 64 * 1024];
 
     for entry in entries {
-        let mut entry = entry.map_err(|err| ArchiveError::Malformed {
-            uri: uri.to_string(),
-            reason: err.to_string(),
-        })?;
+        let mut entry = entry.map_err(malformed)?;
 
         // A directory is not a candidate, and neither is a symlink or any other special entry.
         if !entry.header().entry_type().is_file() {
@@ -59,33 +108,39 @@ fn from_tar<R: Read>(stream: R, uri: &str) -> Result<Vec<u8>, ArchiveError> {
         }
 
         // A second file settles it, so there is nothing to learn from the rest of the stream.
-        if only.is_some() {
+        if found {
             return Err(ArchiveError::NonZeroFiles { uri: uri.to_string() });
         }
+        found = true;
 
-        let mut body = Vec::new();
-        entry.read_to_end(&mut body).map_err(|err| ArchiveError::Malformed {
-            uri: uri.to_string(),
-            reason: err.to_string(),
-        })?;
-        only = Some(body);
+        // Copied by hand rather than with `io::copy`, which gives both sides one error type: a
+        // destination that cannot be written to says nothing about whether the archive reads.
+        loop {
+            let read = entry.read(&mut buffer).map_err(malformed)?;
+            if read == 0 {
+                break;
+            }
+            out.write_all(&buffer[..read]).map_err(|err| ArchiveError::Unwritable {
+                uri: uri.to_string(),
+                reason: err.to_string(),
+            })?;
+        }
     }
 
     // Read for the errors it raises rather than for the bytes: whatever follows the tar is the
     // stream's own bookkeeping, and there is nothing left to hand back a decoded byte to.
     let mut rest = tar.into_inner();
-    std::io::copy(&mut rest, &mut std::io::sink()).map_err(|err| ArchiveError::Malformed {
-        uri: uri.to_string(),
-        reason: err.to_string(),
-    })?;
+    std::io::copy(&mut rest, &mut std::io::sink()).map_err(malformed)?;
 
-    only.ok_or_else(|| ArchiveError::Empty { uri: uri.to_string() })
+    if !found {
+        return Err(ArchiveError::Empty { uri: uri.to_string() });
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
-
     use flate2::{Compression, write::GzEncoder};
 
     use super::*;
@@ -94,6 +149,18 @@ mod tests {
 
     /// A gzip stream ends with a CRC32 of the decompressed bytes and their length, four bytes each.
     const TRAILER: usize = 8;
+
+    /// What [extract] writes out for `body`, or the error it refuses with.
+    fn extracted(body: &[u8]) -> Result<Vec<u8>, ArchiveError> {
+        let mut out = Vec::new();
+        extract(body, SupportedFormat::TarGz, URI, &mut out).map(|()| out)
+    }
+
+    /// What [extract] writes out for `body` under a limit of `limit`, or the error it refuses with.
+    fn extracted_under(limit: u64, body: &[u8]) -> Result<Vec<u8>, ArchiveError> {
+        let mut out = Vec::new();
+        extract_bounded(body, SupportedFormat::TarGz, URI, &mut out, limit).map(|()| out)
+    }
 
     /// A gzipped tar archive of `(path, contents)` entries.
     fn tarball(entries: &[(&str, &[u8])]) -> Vec<u8> {
@@ -142,15 +209,23 @@ mod tests {
 
     #[test]
     fn the_sole_file_is_extracted() {
-        let extracted = file(&nested(), SupportedFormat::TarGz, URI).expect("should extract");
+        let extracted = extracted(&nested()).expect("should extract");
         assert_eq!(extracted, b"binary", "the directory entry must not count as a file");
+    }
+
+    /// Bigger than the copy buffer, so the chunk loop is exercised across several reads.
+    #[test]
+    fn a_file_larger_than_the_copy_buffer_arrives_whole() {
+        let contents: Vec<u8> = (0..300_000u32).map(|byte| byte as u8).collect();
+
+        let extracted = extracted(&tarball(&[("big", &contents)])).expect("should extract");
+        assert_eq!(extracted, contents, "every read must reach the writer, in order");
     }
 
     /// Which of two files is the artifact is not something to guess.
     #[test]
     fn several_files_is_an_error() {
-        let err = file(&tarball(&[("a", b"one"), ("b", b"two")]), SupportedFormat::TarGz, URI)
-            .expect_err("must fail");
+        let err = extracted(&tarball(&[("a", b"one"), ("b", b"two")])).expect_err("must fail");
         assert!(matches!(err, ArchiveError::NonZeroFiles { .. }), "{err}");
         assert!(err.to_string().contains(URI), "the message must name the source: {err}");
     }
@@ -160,8 +235,7 @@ mod tests {
         let mut tar = tar::Builder::new(Vec::new());
         tar.append(&directory("empty/"), std::io::empty()).unwrap();
 
-        let err = file(&gzipped(tar.into_inner().unwrap()), SupportedFormat::TarGz, URI)
-            .expect_err("must fail");
+        let err = extracted(&gzipped(tar.into_inner().unwrap())).expect_err("must fail");
         assert!(matches!(err, ArchiveError::Empty { .. }), "{err}");
     }
 
@@ -172,7 +246,7 @@ mod tests {
         let mut body = nested();
         body.truncate(body.len() - TRAILER);
 
-        let err = file(&body, SupportedFormat::TarGz, URI).expect_err("must fail");
+        let err = extracted(&body).expect_err("must fail");
         assert!(matches!(err, ArchiveError::Malformed { .. }), "{err}");
         assert!(err.to_string().contains(URI), "the message must name the source: {err}");
     }
@@ -185,16 +259,65 @@ mod tests {
         let crc = body.len() - TRAILER;
         body[crc] ^= 0xff;
 
-        let err = file(&body, SupportedFormat::TarGz, URI).expect_err("must fail");
+        let err = extracted(&body).expect_err("must fail");
         assert!(matches!(err, ArchiveError::Malformed { .. }), "{err}");
     }
 
     /// Not an archive at all -- an HTML error page served with a 200, say.
     #[test]
     fn garbage_is_reported_as_a_malformed_archive() {
-        let err = file(b"<html>not a tarball</html>", SupportedFormat::TarGz, URI)
-            .expect_err("must fail");
+        let err = extracted(b"<html>not a tarball</html>").expect_err("must fail");
         assert!(matches!(err, ArchiveError::Malformed { .. }), "{err}");
         assert!(err.to_string().contains(URI), "the message must name the source: {err}");
+    }
+
+    /// A destination that refuses the bytes is not a defect in the archive.
+    #[test]
+    fn a_writer_that_fails_is_reported_as_such() {
+        struct Full;
+        impl Write for Full {
+            fn write(&mut self, _: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::other("no space left on device"))
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let err =
+            extract(&nested(), SupportedFormat::TarGz, URI, &mut Full).expect_err("must fail");
+        assert!(matches!(err, ArchiveError::Unwritable { .. }), "{err}");
+        assert!(err.to_string().contains(URI), "the message must name the source: {err}");
+    }
+
+    /// Compression hides how much there is to unpack, so the amount is capped as it comes out.
+    #[test]
+    fn an_archive_that_unpacks_past_the_limit_is_refused() {
+        // What a gzip bomb is made of: all one byte, so a little compressed stands for a lot.
+        let body = tarball(&[("big", &vec![0u8; 512 * 1024])]);
+        assert!(body.len() < 4096, "the compressed size must say nothing about the unpacked one");
+
+        let limit = 64 * 1024;
+        let err = extracted_under(limit, &body).expect_err("must fail");
+
+        assert!(matches!(err, ArchiveError::TooLarge { .. }), "{err}");
+        assert!(err.to_string().contains(URI), "the message must name the source: {err}");
+        assert!(
+            err.to_string().contains(&limit.to_string()),
+            "the message must name the limit: {err}"
+        );
+    }
+
+    /// The limit is the amount refused, not an amount to stop short of.
+    #[test]
+    fn an_archive_that_ends_on_the_limit_is_accepted() {
+        let body = tarball(&[("snug", b"contents")]);
+        let mut plain = Vec::new();
+        flate2::read::GzDecoder::new(&body[..]).read_to_end(&mut plain).unwrap();
+
+        let extracted = extracted_under(plain.len() as u64, &body)
+            .expect("a stream exactly the limit's length must be read");
+        assert_eq!(extracted, b"contents");
     }
 }

--- a/src/install/archive.rs
+++ b/src/install/archive.rs
@@ -1,0 +1,165 @@
+//! Getting the file out of an archived artifact.
+//!
+//! An artifact is exactly one installed file (spec section 6.1), so the archive must hold exactly
+//! one file. Everything happens in memory: nothing but the artifact is written anywhere.
+//!
+//! # Adding a new supported format
+//!
+//! A reader beside [from_tar], and an arm for it in [file]. A reader takes a stream, so any
+//! decompression composes in front of it; one needing random access -- a zip's central directory
+//! sits at the end -- can take the whole body instead.
+
+use std::io::Read;
+
+use crate::artifact::SupportedFormat;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ArchiveError {
+    #[error("failed to read the archive fetched from '{uri}': {reason}")]
+    Malformed { uri: String, reason: String },
+    #[error("the archive fetched from '{uri}' contains more than one file")]
+    NonZeroFiles { uri: String },
+    #[error("the archive fetched from '{uri}' contains no files at all")]
+    Empty { uri: String },
+}
+
+/// Reads the one file `body` holds, as packaged by `format`.
+///
+/// Every format has a reader by construction: [SupportedFormat] is exactly the set this build can
+/// read, so there is no unreadable case to report from here.
+///
+/// `uri` is only used to say what failed: the bytes are already in hand.
+pub fn file(body: &[u8], format: SupportedFormat, uri: &str) -> Result<Vec<u8>, ArchiveError> {
+    match format {
+        SupportedFormat::TarGz => from_tar(flate2::read::GzDecoder::new(body), uri),
+    }
+}
+
+/// Reads the sole regular file out of a tar stream.
+fn from_tar<R: Read>(stream: R, uri: &str) -> Result<Vec<u8>, ArchiveError> {
+    let mut tar = tar::Archive::new(stream);
+    let entries = tar.entries().map_err(|err| ArchiveError::Malformed {
+        uri: uri.to_string(),
+        reason: err.to_string(),
+    })?;
+
+    // Held as bytes rather than as a position, because a decompressing stream cannot be rewound to
+    // come back for it.
+    let mut only: Option<Vec<u8>> = None;
+
+    for entry in entries {
+        let mut entry = entry.map_err(|err| ArchiveError::Malformed {
+            uri: uri.to_string(),
+            reason: err.to_string(),
+        })?;
+
+        // A directory is not a candidate, and neither is a symlink or any other special entry.
+        if !entry.header().entry_type().is_file() {
+            continue;
+        }
+
+        // A second file settles it, so there is nothing to learn from the rest of the stream.
+        if only.is_some() {
+            return Err(ArchiveError::NonZeroFiles { uri: uri.to_string() });
+        }
+
+        let mut body = Vec::new();
+        entry.read_to_end(&mut body).map_err(|err| ArchiveError::Malformed {
+            uri: uri.to_string(),
+            reason: err.to_string(),
+        })?;
+        only = Some(body);
+    }
+
+    only.ok_or_else(|| ArchiveError::Empty { uri: uri.to_string() })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use flate2::{Compression, write::GzEncoder};
+
+    use super::*;
+
+    const URI: &str = "https://example.invalid/artifact.tar.gz";
+
+    /// A gzipped tar archive of `(path, contents)` entries.
+    fn tarball(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut tar = tar::Builder::new(Vec::new());
+        for (path, contents) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(contents.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            tar.append_data(&mut header, path, *contents).unwrap();
+        }
+        gzipped(tar.into_inner().unwrap())
+    }
+
+    fn gzipped(plain: Vec<u8>) -> Vec<u8> {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&plain).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    fn directory(path: &str) -> tar::Header {
+        let mut header = tar::Header::new_gnu();
+        header.set_entry_type(tar::EntryType::Directory);
+        header.set_size(0);
+        header.set_mode(0o755);
+        header.set_path(path).unwrap();
+        header.set_cksum();
+        header
+    }
+
+    /// A directory entry with the binary nested inside it, as most release tarballs are laid out.
+    fn nested() -> Vec<u8> {
+        let mut tar = tar::Builder::new(Vec::new());
+        tar.append(&directory("miden-vm-aarch64-apple-darwin/"), std::io::empty())
+            .unwrap();
+
+        let mut header = tar::Header::new_gnu();
+        header.set_size(6);
+        header.set_mode(0o755);
+        header.set_cksum();
+        tar.append_data(&mut header, "miden-vm-aarch64-apple-darwin/miden-vm", &b"binary"[..])
+            .unwrap();
+
+        gzipped(tar.into_inner().unwrap())
+    }
+
+    #[test]
+    fn the_sole_file_is_extracted() {
+        let extracted = file(&nested(), SupportedFormat::TarGz, URI).expect("should extract");
+        assert_eq!(extracted, b"binary", "the directory entry must not count as a file");
+    }
+
+    /// Which of two files is the artifact is not something to guess.
+    #[test]
+    fn several_files_is_an_error() {
+        let err = file(&tarball(&[("a", b"one"), ("b", b"two")]), SupportedFormat::TarGz, URI)
+            .expect_err("must fail");
+        assert!(matches!(err, ArchiveError::NonZeroFiles { .. }), "{err}");
+        assert!(err.to_string().contains(URI), "the message must name the source: {err}");
+    }
+
+    #[test]
+    fn an_archive_with_no_files_is_an_error() {
+        let mut tar = tar::Builder::new(Vec::new());
+        tar.append(&directory("empty/"), std::io::empty()).unwrap();
+
+        let err = file(&gzipped(tar.into_inner().unwrap()), SupportedFormat::TarGz, URI)
+            .expect_err("must fail");
+        assert!(matches!(err, ArchiveError::Empty { .. }), "{err}");
+    }
+
+    /// Not an archive at all -- an HTML error page served with a 200, say.
+    #[test]
+    fn garbage_is_reported_as_a_malformed_archive() {
+        let err = file(b"<html>not a tarball</html>", SupportedFormat::TarGz, URI)
+            .expect_err("must fail");
+        assert!(matches!(err, ArchiveError::Malformed { .. }), "{err}");
+        assert!(err.to_string().contains(URI), "the message must name the source: {err}");
+    }
+}

--- a/src/install/cargo.rs
+++ b/src/install/cargo.rs
@@ -423,6 +423,7 @@ mod tests {
             mode: 0o755,
             owner: "x".to_string(),
             digest: None,
+            archive: None,
             fallback: None,
         };
         assert!(argv_for(&step, Path::new("/s"), false, true).is_empty());

--- a/src/install/download.rs
+++ b/src/install/download.rs
@@ -12,13 +12,21 @@
 //!
 //! The temporary file an artifact stages through is unique per attempt, not derived from the
 //! destination's stem: `core.masp` and `core.wasm` must not stage through the same path.
+//!
+//! An archived artifact takes the same path with one step inserted: the file inside the transferred
+//! bytes is read out (see [crate::install::archive]) and *that* is what gets published. It happens
+//! in memory, so nothing but the artifact is ever written.
 
 use std::{
     io::Write,
     path::{Path, PathBuf},
 };
 
-use crate::plan::PlanStep;
+use crate::{
+    artifact::SupportedFormat,
+    install::{ArchiveError, archive},
+    plan::PlanStep,
+};
 
 /// How many redirects to follow before giving up.
 ///
@@ -53,6 +61,8 @@ pub enum ExecError {
         #[source]
         source: std::io::Error,
     },
+    #[error(transparent)]
+    Archive(#[from] ArchiveError),
 }
 
 /// Performs one acquisition step.
@@ -61,26 +71,52 @@ pub enum ExecError {
 /// Cargo executor. Every path is taken verbatim from the plan.
 pub fn acquire(step: &PlanStep) -> Result<(), ExecError> {
     match step {
-        PlanStep::Download { uri, dest, mode, .. } => download(uri, dest, *mode),
-        PlanStep::CopyLocal { src, dest, mode, .. } => copy_local(src, dest, *mode),
+        PlanStep::Download { uri, dest, mode, archive, .. } => download(uri, dest, *mode, *archive),
+        PlanStep::CopyLocal { src, dest, mode, archive, .. } => {
+            copy_local(src, dest, *mode, *archive)
+        },
         PlanStep::CargoBuild { .. } | PlanStep::ExtractPackage { .. } => Ok(()),
     }
 }
 
-/// Fetches `uri` to `dest`, atomically.
-pub fn download(uri: &str, dest: &Path, mode: u32) -> Result<(), ExecError> {
+/// Fetches `uri` to `dest`, atomically, unpacking it first when it is an archive.
+pub fn download(
+    uri: &str,
+    dest: &Path,
+    mode: u32,
+    archive: Option<SupportedFormat>,
+) -> Result<(), ExecError> {
     let body = fetch(uri)?;
-    publish(&body, dest, mode)
+    publish(&unpack(body, archive, uri)?, dest, mode)
 }
 
-/// Copies `src` to `dest`, atomically.
-pub fn copy_local(src: &Path, dest: &Path, mode: u32) -> Result<(), ExecError> {
+/// Copies `src` to `dest`, atomically, unpacking it first when it is an archive.
+pub fn copy_local(
+    src: &Path,
+    dest: &Path,
+    mode: u32,
+    archive: Option<SupportedFormat>,
+) -> Result<(), ExecError> {
     let body = std::fs::read(src).map_err(|source| ExecError::Copy {
         src: src.to_path_buf(),
         dest: dest.to_path_buf(),
         source,
     })?;
-    publish(&body, dest, mode)
+    let source = format!("file://{}", src.display());
+    publish(&unpack(body, archive, &source)?, dest, mode)
+}
+
+/// Reduces acquired bytes to the artifact: the one file the archive holds, or the bytes as they
+/// came.
+fn unpack(
+    body: Vec<u8>,
+    archive: Option<SupportedFormat>,
+    source: &str,
+) -> Result<Vec<u8>, ExecError> {
+    match archive {
+        Some(format) => Ok(archive::file(&body, format, source)?),
+        None => Ok(body),
+    }
 }
 
 /// Retrieves `uri`, rejecting anything that is not a usable body.
@@ -195,6 +231,8 @@ fn temporary_sibling(dest: &Path) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
+    use flate2::{Compression, write::GzEncoder};
+
     use super::*;
 
     /// A single-request HTTP server, so status handling is exercised against a real socket.
@@ -276,7 +314,7 @@ mod tests {
         let dir = temp();
         let dest = dir.path().join("artifact.bin");
 
-        let err = download(&server.url("/x"), &dest, 0o755).expect_err("a 404 must fail");
+        let err = download(&server.url("/x"), &dest, 0o755, None).expect_err("a 404 must fail");
         assert!(matches!(err, ExecError::HttpStatus { status: 404, .. }), "{err}");
         assert!(!dest.exists(), "a failed download must not leave a file");
         assert!(leftovers(dir.path(), "artifact.bin").is_empty(), "no partial files");
@@ -288,7 +326,7 @@ mod tests {
         let dir = temp();
         let dest = dir.path().join("a.bin");
 
-        let err = download(&server.url("/x"), &dest, 0o755).expect_err("a 500 must fail");
+        let err = download(&server.url("/x"), &dest, 0o755, None).expect_err("a 500 must fail");
         assert!(matches!(err, ExecError::HttpStatus { status: 500, .. }), "{err}");
         assert!(!dest.exists());
     }
@@ -300,7 +338,8 @@ mod tests {
         let dir = temp();
         let dest = dir.path().join("a.bin");
 
-        let err = download(&server.url("/x"), &dest, 0o755).expect_err("an empty body must fail");
+        let err =
+            download(&server.url("/x"), &dest, 0o755, None).expect_err("an empty body must fail");
         assert!(matches!(err, ExecError::EmptyBody { .. }), "{err}");
         assert!(!dest.exists());
     }
@@ -311,7 +350,7 @@ mod tests {
         let dir = temp();
         let dest = dir.path().join("planned-name.bin");
 
-        download(&server.url("/x"), &dest, 0o755).expect("should succeed");
+        download(&server.url("/x"), &dest, 0o755, None).expect("should succeed");
         assert_eq!(std::fs::read(&dest).unwrap(), b"payload");
         assert!(leftovers(dir.path(), "planned-name.bin").is_empty());
     }
@@ -323,7 +362,7 @@ mod tests {
         let dir = temp();
         let dest = dir.path().join("a.bin");
 
-        download(&server.url("/from"), &dest, 0o755).expect("redirects must be followed");
+        download(&server.url("/from"), &dest, 0o755, None).expect("redirects must be followed");
         assert_eq!(std::fs::read(&dest).unwrap(), b"payload");
     }
 
@@ -334,7 +373,7 @@ mod tests {
         let dir = temp();
         let dest = dir.path().join("nothing-like-the-url");
 
-        download(&server.url("/some/deep/path/other-name"), &dest, 0o755).unwrap();
+        download(&server.url("/some/deep/path/other-name"), &dest, 0o755, None).unwrap();
         assert!(dest.exists(), "the planned name must win");
     }
 
@@ -348,13 +387,82 @@ mod tests {
             let dir = temp();
             let dest = dir.path().join("pkg.masp");
 
-            download(&server.url("/x"), &dest, 0o644).unwrap();
+            download(&server.url("/x"), &dest, 0o644, None).unwrap();
             assert_eq!(
                 std::fs::metadata(&dest).unwrap().permissions().mode() & 0o777,
                 0o644,
                 "packages must not be marked executable"
             );
         }
+    }
+
+    /// A gzipped tarball with the binary nested under a release directory, as releases ship them.
+    fn tarball(member: &str, contents: &[u8]) -> Vec<u8> {
+        use std::io::Write;
+
+        let mut tar = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        // Deliberately not 0755: the mode comes from the plan, never from the archive.
+        header.set_mode(0o600);
+        header.set_cksum();
+        tar.append_data(&mut header, member, contents).unwrap();
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&tar.into_inner().unwrap()).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    /// The archived file lands at the planned path with the planned name and mode.
+    #[test]
+    fn an_archived_download_installs_the_file_the_archive_holds() {
+        let body = Box::leak(tarball("vm-0.16.0/miden-vm", b"binary").into_boxed_slice());
+        let server = TestServer::responding(200, body);
+        let dir = temp();
+        let dest = dir.path().join("miden-vm");
+
+        download(&server.url("/vm.tar.gz"), &dest, 0o755, Some(SupportedFormat::TarGz))
+            .expect("should succeed");
+
+        assert_eq!(std::fs::read(&dest).unwrap(), b"binary");
+        assert!(leftovers(dir.path(), "miden-vm").is_empty(), "nothing else may be unpacked");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                std::fs::metadata(&dest).unwrap().permissions().mode() & 0o777,
+                0o755,
+                "the mode comes from the plan, not from the archive entry"
+            );
+        }
+    }
+
+    /// A local archive is unpacked the same way a fetched one is.
+    #[test]
+    fn an_archived_local_copy_installs_the_file_the_archive_holds() {
+        let dir = temp();
+        let src = dir.path().join("core.tar.gz");
+        std::fs::write(&src, tarball("packages/core.masp", b"package")).unwrap();
+        let dest = dir.path().join("lib").join("core.masp");
+
+        copy_local(&src, &dest, 0o644, Some(SupportedFormat::TarGz)).expect("should succeed");
+        assert_eq!(std::fs::read(&dest).unwrap(), b"package");
+    }
+
+    /// An unreadable archive fails like any other unusable body: nothing on disk, container
+    /// included.
+    #[test]
+    fn an_unreadable_archive_writes_nothing() {
+        let server = TestServer::responding(200, b"<html>Not a tarball</html>");
+        let dir = temp();
+        let dest = dir.path().join("miden-vm");
+
+        let err = download(&server.url("/vm.tar.gz"), &dest, 0o755, Some(SupportedFormat::TarGz))
+            .expect_err("must fail");
+        assert!(matches!(err, ExecError::Archive(_)), "{err}");
+        assert!(!dest.exists(), "the container must never be installed as the artifact");
+        assert!(leftovers(dir.path(), "miden-vm").is_empty(), "no partial files");
     }
 
     #[test]
@@ -364,14 +472,14 @@ mod tests {
         std::fs::write(&src, b"local").unwrap();
         let dest = dir.path().join("nested").join("dest");
 
-        copy_local(&src, &dest, 0o644).expect("should succeed");
+        copy_local(&src, &dest, 0o644, None).expect("should succeed");
         assert_eq!(std::fs::read(&dest).unwrap(), b"local", "parent dirs must be created");
     }
 
     #[test]
     fn a_missing_local_source_is_an_error() {
         let dir = temp();
-        let err = copy_local(&dir.path().join("nope"), &dir.path().join("dest"), 0o644)
+        let err = copy_local(&dir.path().join("nope"), &dir.path().join("dest"), 0o644, None)
             .expect_err("must fail");
         assert!(matches!(err, ExecError::Copy { .. }), "{err}");
     }

--- a/src/install/download.rs
+++ b/src/install/download.rs
@@ -14,8 +14,9 @@
 //! destination's stem: `core.masp` and `core.wasm` must not stage through the same path.
 //!
 //! An archived artifact takes the same path with one step inserted: the file inside the transferred
-//! bytes is read out (see [crate::install::archive]) and *that* is what gets published. It happens
-//! in memory, so nothing but the artifact is ever written.
+//! bytes is read out (see [crate::install::archive]) and *that* is what gets published. It is
+//! streamed into the temporary as it is unpacked, so the artifact is never held in memory alongside
+//! the bytes it came out of, and the container is never written anywhere.
 
 use std::{
     io::Write,
@@ -87,7 +88,7 @@ pub fn download(
     archive: Option<SupportedFormat>,
 ) -> Result<(), ExecError> {
     let body = fetch(uri)?;
-    publish(&unpack(body, archive, uri)?, dest, mode)
+    publish(&body, archive, uri, dest, mode)
 }
 
 /// Copies `src` to `dest`, atomically, unpacking it first when it is an archive.
@@ -103,20 +104,7 @@ pub fn copy_local(
         source,
     })?;
     let source = format!("file://{}", src.display());
-    publish(&unpack(body, archive, &source)?, dest, mode)
-}
-
-/// Reduces acquired bytes to the artifact: the one file the archive holds, or the bytes as they
-/// came.
-fn unpack(
-    body: Vec<u8>,
-    archive: Option<SupportedFormat>,
-    source: &str,
-) -> Result<Vec<u8>, ExecError> {
-    match archive {
-        Some(format) => Ok(archive::file(&body, format, source)?),
-        None => Ok(body),
-    }
+    publish(&body, archive, &source, dest, mode)
 }
 
 /// Retrieves `uri`, rejecting anything that is not a usable body.
@@ -168,27 +156,39 @@ fn fetch(uri: &str) -> Result<Vec<u8>, ExecError> {
     Ok(body)
 }
 
-/// Writes `body` to a unique temporary sibling of `dest`, then renames it into place.
+/// Writes the artifact `body` carries to a unique temporary sibling of `dest`, then renames it into
+/// place. `body` can either be the artifact itself or the archive holding it.
 ///
 /// The temporary is a sibling so the rename stays within one filesystem, and unique so that two
 /// artifacts sharing a stem cannot stage through the same path.
-fn publish(body: &[u8], dest: &Path, mode: u32) -> Result<(), ExecError> {
+fn publish(
+    body: &[u8],
+    archive: Option<SupportedFormat>,
+    source: &str,
+    dest: &Path,
+    mode: u32,
+) -> Result<(), ExecError> {
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|source| ExecError::Create { path: parent.to_path_buf(), source })?;
     }
 
     let temporary = temporary_sibling(dest);
-    let result = (|| -> std::io::Result<()> {
-        let mut file = std::fs::File::create(&temporary)?;
-        file.write_all(body)?;
-        file.flush()?;
-        file.sync_all()?;
+    let unusable = |source: std::io::Error| ExecError::Create { path: temporary.clone(), source };
+
+    let result = (|| -> Result<(), ExecError> {
+        let mut file = std::fs::File::create(&temporary).map_err(unusable)?;
+        match archive {
+            Some(format) => archive::extract(body, format, source, &mut file)?,
+            None => file.write_all(body).map_err(unusable)?,
+        }
+        file.flush().map_err(unusable)?;
+        file.sync_all().map_err(unusable)?;
 
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            file.set_permissions(std::fs::Permissions::from_mode(mode))?;
+            file.set_permissions(std::fs::Permissions::from_mode(mode)).map_err(unusable)?;
         }
         #[cfg(not(unix))]
         let _ = mode;
@@ -196,9 +196,9 @@ fn publish(body: &[u8], dest: &Path, mode: u32) -> Result<(), ExecError> {
         Ok(())
     })();
 
-    if let Err(source) = result {
+    if let Err(err) = result {
         let _ = std::fs::remove_file(&temporary);
-        return Err(ExecError::Create { path: temporary, source });
+        return Err(err);
     }
 
     if let Err(source) = std::fs::rename(&temporary, dest) {
@@ -413,6 +413,24 @@ mod tests {
         encoder.finish().unwrap()
     }
 
+    /// A gzipped tarball of several members, for the archives that must be refused.
+    fn tarball_of(members: &[(&str, &[u8])]) -> Vec<u8> {
+        use std::io::Write;
+
+        let mut tar = tar::Builder::new(Vec::new());
+        for (path, contents) in members {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(contents.len() as u64);
+            header.set_mode(0o600);
+            header.set_cksum();
+            tar.append_data(&mut header, path, *contents).unwrap();
+        }
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&tar.into_inner().unwrap()).unwrap();
+        encoder.finish().unwrap()
+    }
+
     /// The archived file lands at the planned path with the planned name and mode.
     #[test]
     fn an_archived_download_installs_the_file_the_archive_holds() {
@@ -463,6 +481,26 @@ mod tests {
         assert!(matches!(err, ExecError::Archive(_)), "{err}");
         assert!(!dest.exists(), "the container must never be installed as the artifact");
         assert!(leftovers(dir.path(), "miden-vm").is_empty(), "no partial files");
+    }
+
+    /// The temporary an archive unpacks into is written before the archive has been shown to hold
+    /// exactly one file. Only the rename publishes anything, so a rejected archive leaves nothing.
+    #[test]
+    fn an_archive_holding_more_than_one_file_writes_nothing() {
+        let dir = temp();
+        let src = dir.path().join("two.tar.gz");
+        std::fs::write(&src, tarball_of(&[("first", b"one"), ("second", b"two")])).unwrap();
+        let dest = dir.path().join("miden-vm");
+
+        let err =
+            copy_local(&src, &dest, 0o755, Some(SupportedFormat::TarGz)).expect_err("must fail");
+        assert!(matches!(err, ExecError::Archive(_)), "{err}");
+        assert!(!dest.exists(), "a rejected archive must not be installed");
+        assert_eq!(
+            leftovers(dir.path(), "two.tar.gz"),
+            Vec::<String>::new(),
+            "the temporary the first file was written to must be gone"
+        );
     }
 
     #[test]

--- a/src/install/extract.rs
+++ b/src/install/extract.rs
@@ -166,6 +166,7 @@ mod tests {
             mode: 0o755,
             owner: "x".to_string(),
             digest: None,
+            archive: None,
             fallback: None,
         };
         assert!(render_script(&[download]).is_none(), "downloads need no script");

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -3,12 +3,14 @@
 //! Everything here is deliberately decision-free: the plan says what to do, and these modules do
 //! exactly that. No filtering, no name resolution, no manifest access.
 
+pub mod archive;
 pub mod cargo;
 pub mod download;
 pub mod extract;
 pub mod stage;
 
 pub use self::{
+    archive::ArchiveError,
     cargo::{CargoError, argv_for, build as cargo_build},
     download::{ExecError, acquire},
     extract::{ExtractError, extract, render_script},

--- a/src/install/stage.rs
+++ b/src/install/stage.rs
@@ -317,6 +317,7 @@ mod tests {
         let artifact = |name: &str| Artifact::TargetAgnostic {
             uri: uri(name),
             digest: None,
+            archive: None,
             extra: Default::default(),
         };
 
@@ -681,6 +682,7 @@ mod tests {
             dest,
             mode: MODE_EXECUTABLE,
             owner: "vm".to_string(),
+            archive: None,
             fallback: None,
         };
 
@@ -710,11 +712,13 @@ mod tests {
             dest: dest.clone(),
             mode: MODE_EXECUTABLE,
             owner: "vm".to_string(),
+            archive: None,
             fallback: Some(Box::new(PlanStep::CopyLocal {
                 src: replacement,
                 dest: dest.clone(),
                 mode: MODE_EXECUTABLE,
                 owner: "vm".to_string(),
+                archive: None,
                 fallback: None,
             })),
         };

--- a/src/manifest/v1/component.rs
+++ b/src/manifest/v1/component.rs
@@ -178,6 +178,8 @@ impl TryFrom<Component> for crate::manifest::v3::Component {
                     crate::artifact::Artifact::TargetAgnostic {
                         uri: artifact,
                         digest: None,
+                        // A v1 manifest had no way to declare one: every artifact was the file.
+                        archive: None,
                         extra: Default::default(),
                     },
                 );
@@ -190,6 +192,7 @@ impl TryFrom<Component> for crate::manifest::v3::Component {
                             substitutions: None,
                             targets: Default::default(),
                             digest: None,
+                            archive: None,
                             extra: Default::default(),
                         }
                     });
@@ -206,6 +209,7 @@ impl TryFrom<Component> for crate::manifest::v3::Component {
                             substitutions: None,
                             targets: Default::default(),
                             digest: None,
+                            archive: None,
                             extra: Default::default(),
                         }
                     });

--- a/src/manifest/validate.rs
+++ b/src/manifest/validate.rs
@@ -114,6 +114,28 @@ pub enum ValidationError {
          else selects one"
     )]
     MissingDefaultNetwork(&'static str),
+    #[error(
+        "channel {channel}: artifact '{artifact}' of component '{component}' declares archive \
+         format '{format}', which midenup cannot read; supported formats are {supported}"
+    )]
+    UnsupportedArchiveFormat {
+        channel: semver::Version,
+        component: String,
+        artifact: String,
+        format: String,
+        supported: String,
+    },
+    #[error(
+        "channel {channel}: artifact '{artifact}' of component '{component}' is fetched from a \
+         '{format}' archive but does not declare one, so the archive itself would be installed as \
+         '{artifact}'; add \"archive\": \"{format}\""
+    )]
+    UndeclaredArchive {
+        channel: semver::Version,
+        component: String,
+        artifact: String,
+        format: &'static str,
+    },
 }
 
 /// Validates a whole manifest, returning every problem found.
@@ -294,12 +316,65 @@ fn validate_names(channel: &Channel, errors: &mut Vec<ValidationError>) {
             });
         }
 
-        for id in component.artifacts.artifacts.keys() {
+        for (id, artifact) in component.artifacts.artifacts.iter() {
             if let Err(err) = validate_artifact_id(id) {
                 errors.push(invalid("artifact id", err.to_string()));
             }
+
+            // Stricter than parsing on purpose: an unreadable format parses, so that one channel
+            // cannot break every other command (spec section 4.4), but nothing should be
+            // *published* that the publishing build cannot install.
+            match artifact.archive() {
+                Some(archive) if !archive.format.is_supported() => {
+                    errors.push(ValidationError::UnsupportedArchiveFormat {
+                        channel: channel.name.clone(),
+                        component: component.name.to_string(),
+                        artifact: id.to_string(),
+                        format: archive.format.to_string(),
+                        // From the format table, so adding a format updates what this reports.
+                        supported: crate::artifact::ArchiveFormat::supported_spellings()
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                    });
+                },
+                Some(_) => {},
+                None => {
+                    if let Some(format) = undeclared_archive(id, artifact, component) {
+                        errors.push(ValidationError::UndeclaredArchive {
+                            channel: channel.name.clone(),
+                            component: component.name.to_string(),
+                            artifact: id.to_string(),
+                            format,
+                        });
+                    }
+                },
+            }
         }
     }
+}
+
+/// The archive format an artifact is evidently fetched from while declaring none.
+///
+/// This is the one artifact mistake nothing downstream can catch: the container arrives as a
+/// regular file of the planned mode, so it installs, verifies and records as a success, and only
+/// fails when something tries to run it. Judged on the *resolved* URI, so a `%extension` of
+/// `tar.gz` is seen the same as a literal one.
+///
+/// An artifact id carrying the same extension is left alone: `bundle.tar.gz` installed as
+/// `bundle.tar.gz` is asking for the archive itself, which is a legitimate thing to want.
+fn undeclared_archive(
+    id: &str,
+    artifact: &crate::artifact::Artifact,
+    component: &Component,
+) -> Option<&'static str> {
+    // Best effort: an artifact whose URI cannot be resolved at all has its own errors, and platform
+    // -specific resolution is not this validator's business.
+    let uris = artifact.get_uris_for(id, component).ok()?;
+
+    crate::artifact::ArchiveFormat::supported_spellings().find(|spelling| {
+        let suffix = format!(".{spelling}");
+        !id.ends_with(&suffix) && uris.iter().any(|uri| uri.to_string().ends_with(&suffix))
+    })
 }
 
 fn validate_destinations(channel: &Channel, errors: &mut Vec<ValidationError>) {
@@ -416,6 +491,7 @@ mod tests {
             Artifact::TargetAgnostic {
                 uri: "https://example.invalid/x".to_string(),
                 digest: None,
+                archive: None,
                 extra: Default::default(),
             },
         );
@@ -625,6 +701,102 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, ValidationError::InvalidName { field: "artifact id", .. }))
         );
+    }
+
+    /// Parsing accepts an unreadable container so an unrelated channel stays usable; publishing one
+    /// is a different matter.
+    #[test]
+    fn an_unreadable_archive_format_is_rejected_for_publication() {
+        let mut c = component("vm", ComponentKind::Package);
+        c.artifacts.insert(
+            "core.masp".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "uri": "https://example.invalid/core.zip",
+                "archive": "zip"
+            }))
+            .expect("an unknown format must still parse"),
+        );
+
+        let errors = errors_of(&manifest(vec![c]));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::UnsupportedArchiveFormat { .. })),
+            "{errors:?}"
+        );
+    }
+
+    #[test]
+    fn a_readable_archive_declaration_validates() {
+        let mut c = component("vm", ComponentKind::Package);
+        c.artifacts.insert(
+            "core.masp".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "uri": "https://example.invalid/core.tar.gz",
+                "archive": "tar.gz"
+            }))
+            .expect("must parse"),
+        );
+
+        assert!(validate_manifest(&with_mainnet(manifest(vec![c]))).is_ok());
+    }
+
+    /// The mistake nothing downstream can catch: without the declaration the container installs as
+    /// the artifact, and only fails when something runs it.
+    #[test]
+    fn an_archive_uri_without_an_archive_declaration_is_rejected() {
+        let mut c = component("vm", ComponentKind::Package);
+        c.artifacts.insert(
+            "core.masp".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "uri": "https://example.invalid/core.masp.tar.gz"
+            }))
+            .expect("must parse"),
+        );
+
+        let errors = errors_of(&manifest(vec![c]));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::UndeclaredArchive { format: "tar.gz", .. })),
+            "{errors:?}"
+        );
+    }
+
+    /// Judged on the resolved URI, so a per-target `%extension` is seen like a literal suffix.
+    #[test]
+    fn a_substituted_archive_extension_is_also_caught() {
+        let mut c = component("vm", ComponentKind::Package);
+        c.artifacts.insert(
+            "core.masp".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "uri": "https://example.invalid/%basename-%target.%extension",
+                "extension": "tar.gz",
+                "targets": {"aarch64-apple-darwin": {}}
+            }))
+            .expect("must parse"),
+        );
+
+        let errors = errors_of(&manifest(vec![c]));
+        assert!(
+            errors.iter().any(|e| matches!(e, ValidationError::UndeclaredArchive { .. })),
+            "{errors:?}"
+        );
+    }
+
+    /// An artifact installed *as* the archive is asking for exactly that.
+    #[test]
+    fn an_artifact_named_for_the_archive_is_left_alone() {
+        let mut c = component("assets", ComponentKind::Asset);
+        c.artifacts.insert(
+            "bundle.tar.gz".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "uri": "https://example.invalid/bundle.tar.gz"
+            }))
+            .expect("must parse"),
+        );
+
+        assert!(validate_manifest(&with_mainnet(manifest(vec![c]))).is_ok());
     }
 
     #[test]

--- a/src/manifest/validate.rs
+++ b/src/manifest/validate.rs
@@ -358,7 +358,8 @@ fn validate_names(channel: &Channel, errors: &mut Vec<ValidationError>) {
 /// This is the one artifact mistake nothing downstream can catch: the container arrives as a
 /// regular file of the planned mode, so it installs, verifies and records as a success, and only
 /// fails when something tries to run it. Judged on the *resolved* URI, so a `%extension` of
-/// `tar.gz` is seen the same as a literal one.
+/// `tar.gz` is seen the same as a literal one, and on the path it is fetched from, so a query
+/// string or a fragment cannot carry the extension out of sight.
 ///
 /// An artifact id carrying the same extension is left alone: `bundle.tar.gz` installed as
 /// `bundle.tar.gz` is asking for the archive itself, which is a legitimate thing to want.
@@ -373,7 +374,7 @@ fn undeclared_archive(
 
     crate::artifact::ArchiveFormat::supported_spellings().find(|spelling| {
         let suffix = format!(".{spelling}");
-        !id.ends_with(&suffix) && uris.iter().any(|uri| uri.to_string().ends_with(&suffix))
+        !id.ends_with(&suffix) && uris.iter().any(|uri| uri.path().ends_with(&suffix))
     })
 }
 
@@ -782,6 +783,81 @@ mod tests {
             errors.iter().any(|e| matches!(e, ValidationError::UndeclaredArchive { .. })),
             "{errors:?}"
         );
+    }
+
+    /// The extension is part of what is fetched; a query string is not, and cannot be relied on
+    /// to hide it. Fetching this installs a tarball named `core.masp`.
+    #[test]
+    fn a_query_string_does_not_hide_the_archive_extension() {
+        let mut c = component("vm", ComponentKind::Package);
+        c.artifacts.insert(
+            "core.masp".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "uri": "https://example.invalid/core.masp.tar.gz?download=1"
+            }))
+            .expect("must parse"),
+        );
+
+        let errors = errors_of(&manifest(vec![c]));
+        assert!(
+            errors
+                .iter()
+                .any(|e| matches!(e, ValidationError::UndeclaredArchive { format: "tar.gz", .. })),
+            "{errors:?}"
+        );
+    }
+
+    /// As for a query string: a fragment is not part of what is fetched either.
+    #[test]
+    fn a_fragment_does_not_hide_the_archive_extension() {
+        let mut c = component("vm", ComponentKind::Package);
+        c.artifacts.insert(
+            "core.masp".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "uri": "https://example.invalid/core.masp.tar.gz#sha256"
+            }))
+            .expect("must parse"),
+        );
+
+        let errors = errors_of(&manifest(vec![c]));
+        assert!(
+            errors.iter().any(|e| matches!(e, ValidationError::UndeclaredArchive { .. })),
+            "{errors:?}"
+        );
+    }
+
+    /// A local source is a filesystem path all the way through, `?` included.
+    #[test]
+    fn a_local_archive_without_a_declaration_is_rejected() {
+        let mut c = component("vm", ComponentKind::Package);
+        c.artifacts.insert(
+            "core.masp".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "uri": "file:///releases/core.masp.tar.gz"
+            }))
+            .expect("must parse"),
+        );
+
+        let errors = errors_of(&manifest(vec![c]));
+        assert!(
+            errors.iter().any(|e| matches!(e, ValidationError::UndeclaredArchive { .. })),
+            "{errors:?}"
+        );
+    }
+
+    /// Only the path names the file: a host is not a thing that is fetched.
+    #[test]
+    fn a_host_spelled_like_an_archive_is_left_alone() {
+        let mut c = component("vm", ComponentKind::Package);
+        c.artifacts.insert(
+            "core.masp".to_string(),
+            serde_json::from_value(serde_json::json!({
+                "uri": "https://releases.tar.gz/core.masp"
+            }))
+            .expect("must parse"),
+        );
+
+        assert!(validate_manifest(&with_mainnet(manifest(vec![c]))).is_ok());
     }
 
     /// An artifact installed *as* the archive is asking for exactly that.

--- a/src/plan/build.rs
+++ b/src/plan/build.rs
@@ -11,11 +11,11 @@ use std::{
 };
 
 use crate::{
-    artifact::{ArtifactUri, Digest, InvalidArtifactError},
+    artifact::{ArtifactUri, Digest, InvalidArtifactError, ResolvedArtifact, SupportedFormat},
     manifest::{Channel, Component, ComponentKind, InstallationMethod, PackageInstallationMethod},
     plan::{
-        ComponentInputs, Destination, DestinationError, KeyInputs, PlanKey, ResolvedAuthority,
-        compute_plan_key, destination_for,
+        ArtifactInput, ComponentInputs, Destination, DestinationError, KeyInputs, PlanKey,
+        ResolvedAuthority, compute_plan_key, destination_for,
     },
     resolve::{Intent, ResolutionError, resolve},
 };
@@ -92,6 +92,8 @@ pub enum PlanStep {
         owner: String,
         /// Recorded in the receipt, never verified. See [crate::artifact::Digest].
         digest: Option<Digest>,
+        /// Set when the fetched bytes are an archive to unpack the artifact from.
+        archive: Option<SupportedFormat>,
         /// What to do instead if the transfer fails (spec section 9.3).
         ///
         /// Only a `prebuilt-with-cargo-fallback` component has one, and the planner only ever
@@ -106,6 +108,8 @@ pub enum PlanStep {
         dest: PathBuf,
         mode: u32,
         owner: String,
+        /// As [PlanStep::Download::archive]. A `file://` artifact can be an archive too.
+        archive: Option<SupportedFormat>,
         /// As [PlanStep::Download::fallback]. A `file://` artifact can be missing just as a
         /// download can 404, and the declared fallback is what makes either recoverable.
         fallback: Option<Box<PlanStep>>,
@@ -336,11 +340,11 @@ fn plan_component(
 ) -> Result<(), PlanError> {
     let name = component.name.to_string();
     let declared = component.artifacts.artifacts.len();
-    let available: Vec<(String, ArtifactUri)> = component
+    let available: Vec<(String, ResolvedArtifact)> = component
         .artifacts
         .get_artifacts_for_target(target, component)?
         .into_iter()
-        .map(|(id, uri)| (id.to_string(), uri))
+        .map(|(id, resolved)| (id.to_string(), resolved))
         .collect();
 
     match component.kind() {
@@ -398,7 +402,7 @@ fn plan_component(
                     )?;
                 },
                 InstallationMethod::Prebuilt => {
-                    let Some((id, uri)) = available.into_iter().next() else {
+                    let Some((id, resolved)) = available.into_iter().next() else {
                         // A prebuilt component with no artifact for this target cannot be
                         // installed at all: an empty artifact list would otherwise become an
                         // install that reports success while placing no files.
@@ -407,7 +411,7 @@ fn plan_component(
                             target: target.to_string(),
                         });
                     };
-                    push_transfer(component, &id, uri, destination, steps, inputs);
+                    push_transfer(component, &id, resolved, destination, steps, inputs);
                 },
                 InstallationMethod::PrebuiltWithCargoFallback {
                     crate_name,
@@ -417,7 +421,7 @@ fn plan_component(
                     // The artifact is what will be installed, but the declared fallback travels
                     // with the step: an artifact that 404s at execution time is exactly the
                     // situation the fallback exists for.
-                    Some((id, uri)) => {
+                    Some((id, resolved)) => {
                         let fallback = PlanStep::CargoBuild {
                             crate_name: crate_name.clone(),
                             authority: authority.clone(),
@@ -430,7 +434,7 @@ fn plan_component(
                         push_transfer_with_fallback(
                             component,
                             &id,
-                            uri,
+                            resolved,
                             destination,
                             steps,
                             inputs,
@@ -482,20 +486,20 @@ fn plan_component(
                     target: target.to_string(),
                 });
             }
-            for (id, uri) in available {
+            for (id, resolved) in available {
                 let destination = destination_for(component, &id, sysroot)?;
                 inputs.destinations.push(key_destination(&destination, sysroot));
-                push_transfer(component, &id, uri, destination, steps, inputs);
+                push_transfer(component, &id, resolved, destination, steps, inputs);
             }
             inputs.installation_method = "prebuilt".to_string();
         },
 
         ComponentKind::Command { .. } => {
             // A command may install nothing at all; it is still a real component.
-            for (id, uri) in available {
+            for (id, resolved) in available {
                 let destination = destination_for(component, &id, sysroot)?;
                 inputs.destinations.push(key_destination(&destination, sysroot));
-                push_transfer(component, &id, uri, destination, steps, inputs);
+                push_transfer(component, &id, resolved, destination, steps, inputs);
             }
             inputs.installation_method = "n/a".to_string();
         },
@@ -573,12 +577,12 @@ fn method_tag(method: &InstallationMethod) -> &'static str {
 fn push_transfer(
     component: &Component,
     id: &str,
-    uri: ArtifactUri,
+    resolved: ResolvedArtifact,
     destination: Destination,
     steps: &mut Vec<PlanStep>,
     inputs: &mut ComponentInputs,
 ) {
-    push_transfer_with_fallback(component, id, uri, destination, steps, inputs, None)
+    push_transfer_with_fallback(component, id, resolved, destination, steps, inputs, None)
 }
 
 /// As [push_transfer], with a step to run if the transfer fails.
@@ -590,7 +594,7 @@ fn push_transfer(
 fn push_transfer_with_fallback(
     component: &Component,
     id: &str,
-    uri: ArtifactUri,
+    resolved: ResolvedArtifact,
     destination: Destination,
     steps: &mut Vec<PlanStep>,
     inputs: &mut ComponentInputs,
@@ -598,7 +602,13 @@ fn push_transfer_with_fallback(
 ) {
     let digest = component.artifacts.artifacts.get(id).and_then(|a| a.digest().cloned());
     let fallback = fallback.map(Box::new);
-    inputs.artifacts.push((id.to_string(), uri.to_string()));
+    let ResolvedArtifact { uri, archive } = resolved;
+    // Material: unpacking the same URI installs different bytes than fetching it whole.
+    inputs.artifacts.push(ArtifactInput {
+        id: id.to_string(),
+        uri: uri.to_string(),
+        archive: archive.map(|format| format.as_str().to_string()),
+    });
 
     steps.push(match uri {
         ArtifactUri::File(src) => PlanStep::CopyLocal {
@@ -606,6 +616,7 @@ fn push_transfer_with_fallback(
             dest: destination.path,
             mode: destination.mode,
             owner: component.name.to_string(),
+            archive,
             fallback,
         },
         ArtifactUri::Http(uri) => PlanStep::Download {
@@ -614,6 +625,7 @@ fn push_transfer_with_fallback(
             mode: destination.mode,
             owner: component.name.to_string(),
             digest,
+            archive,
             fallback,
         },
     });
@@ -699,8 +711,15 @@ mod tests {
         Artifact::TargetAgnostic {
             uri: uri.to_string(),
             digest: None,
+            archive: None,
             extra: Default::default(),
         }
+    }
+
+    /// A target-agnostic artifact published as a gzipped tarball.
+    fn archived(uri: &str) -> Artifact {
+        serde_json::from_value(serde_json::json!({"uri": uri, "archive": "tar.gz"}))
+            .expect("must parse")
     }
 
     fn specific(uri: &str, targets: &[&str]) -> Artifact {
@@ -709,6 +728,7 @@ mod tests {
             substitutions: None,
             targets: targets.iter().map(|t| (t.to_string(), Default::default())).collect(),
             digest: None,
+            archive: None,
             extra: Default::default(),
         }
     }
@@ -878,6 +898,88 @@ mod tests {
         )])
         .expect_err("must fail");
         assert!(matches!(err, PlanError::ArtifactIdMismatch { .. }), "{err}");
+    }
+
+    /// Same destination and mode as an unarchived artifact, plus the format to unpack.
+    #[test]
+    fn an_archived_artifact_carries_its_format_into_the_step() {
+        let plan = plan_of(vec![component(
+            "vm",
+            executable_kind(InstallationMethod::Prebuilt, "miden-vm"),
+            &[("miden-vm", archived("https://example.invalid/vm.tar.gz"))],
+        )])
+        .expect("should plan");
+
+        match &plan.steps[0] {
+            PlanStep::Download { dest, mode, archive, .. } => {
+                assert_eq!(dest, &sysroot().join("bin").join("miden-vm"));
+                assert_eq!(*mode, crate::plan::MODE_EXECUTABLE);
+                assert_eq!(
+                    archive.as_ref().map(|format| format.as_str()),
+                    Some("tar.gz"),
+                    "the step must carry the archive format"
+                );
+            },
+            other => panic!("expected a download, got {other:?}"),
+        }
+    }
+
+    /// A local archive is a copy step carrying its format, as a fetched one is a download.
+    #[test]
+    fn a_local_archive_becomes_a_copy_carrying_its_format() {
+        let plan = plan_of(vec![component(
+            "vm",
+            executable_kind(InstallationMethod::Prebuilt, "miden-vm"),
+            &[("miden-vm", archived("file:///tmp/vm.tar.gz"))],
+        )])
+        .expect("should plan");
+
+        assert!(matches!(&plan.steps[0], PlanStep::CopyLocal { archive: Some(_), .. }));
+    }
+
+    /// An unreadable container fails planning, rather than leaving the executor to discover it.
+    #[test]
+    fn an_unreadable_archive_format_fails_planning() {
+        let artifact: Artifact = serde_json::from_value(serde_json::json!({
+            "uri": "https://example.invalid/vm.zip",
+            "archive": "zip"
+        }))
+        .expect("must parse");
+
+        let err = plan_of(vec![component(
+            "vm",
+            executable_kind(InstallationMethod::Prebuilt, "miden-vm"),
+            &[("miden-vm", artifact)],
+        )])
+        .expect_err("must fail");
+        assert!(
+            matches!(
+                err,
+                PlanError::Artifact(
+                    crate::artifact::InvalidArtifactError::UnsupportedArchiveFormat { .. }
+                )
+            ),
+            "{err}"
+        );
+    }
+
+    /// Republishing an artifact as an archive changes the installed bytes, so it must reinstall.
+    #[test]
+    fn packaging_an_artifact_as_an_archive_changes_the_plan_key() {
+        let key = |artifact: Artifact| {
+            plan_of(vec![component(
+                "vm",
+                executable_kind(InstallationMethod::Prebuilt, "miden-vm"),
+                &[("miden-vm", artifact)],
+            )])
+            .expect("should plan")
+            .key
+        };
+        assert_ne!(
+            key(agnostic("https://example.invalid/vm.tar.gz")),
+            key(archived("https://example.invalid/vm.tar.gz")),
+            "unpacking the same URI installs different bytes than fetching it whole"
+        );
     }
 
     #[test]

--- a/src/plan/key.rs
+++ b/src/plan/key.rs
@@ -65,7 +65,12 @@ impl fmt::Display for PlanKey {
 }
 
 /// Field tags. Values are part of the encoding, so they must never be renumbered -- only appended
-/// to, and only alongside a `PREFIX` bump.
+/// to. They are grouped here by meaning, which is not the order they are numbered in.
+///
+/// A new tag needs a `PREFIX` bump when it changes the encoding of an input that is already
+/// expressible: every installed component whose key moves is reinstalled. A tag emitted only for an
+/// input that no manifest could express without it leaves every such key byte-for-byte identical,
+/// and needs no bump.
 mod tag {
     pub const TARGET: u8 = 1;
     pub const COMPONENT: u8 = 2;
@@ -74,12 +79,25 @@ mod tag {
     pub const METHOD: u8 = 5;
     pub const ARTIFACT_ID: u8 = 6;
     pub const ARTIFACT_URI: u8 = 7;
+    /// Emitted only for an artifact declaring an archive, so an unarchived one encodes exactly as
+    /// it does without this tag.
+    pub const ARTIFACT_ARCHIVE: u8 = 14;
     pub const DESTINATION: u8 = 8;
     pub const MODE: u8 = 9;
     pub const CRATE_NAME: u8 = 10;
     pub const FEATURE: u8 = 11;
     pub const RUSTUP_CHANNEL: u8 = 12;
     pub const SYMLINK: u8 = 13;
+}
+
+/// One artifact as the key sees it.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ArtifactInput {
+    pub id: String,
+    /// Fully substituted for the target being planned.
+    pub uri: String,
+    /// The format it is packaged in, if any.
+    pub archive: Option<String>,
 }
 
 /// A canonical byte encoder.
@@ -141,8 +159,8 @@ pub struct ComponentInputs {
     pub authority: String,
     pub kind: String,
     pub installation_method: String,
-    /// `(artifact id, resolved uri)`, in any order.
-    pub artifacts: Vec<(String, String)>,
+    /// Every artifact this component installs, in any order.
+    pub artifacts: Vec<ArtifactInput>,
     /// `(exact destination path, file mode)`, in any order.
     pub destinations: Vec<(String, u32)>,
     pub crate_name: Option<String>,
@@ -176,9 +194,13 @@ pub fn compute(inputs: &KeyInputs) -> PlanKey {
 
         let mut artifacts = component.artifacts.clone();
         artifacts.sort();
-        for (id, uri) in artifacts.iter() {
-            encoder.text(tag::ARTIFACT_ID, id);
-            encoder.text(tag::ARTIFACT_URI, uri);
+        for artifact in artifacts.iter() {
+            encoder.text(tag::ARTIFACT_ID, &artifact.id);
+            encoder.text(tag::ARTIFACT_URI, &artifact.uri);
+            // Absent emits nothing at all, not an absence marker: see `tag::ARTIFACT_ARCHIVE`.
+            if let Some(archive) = artifact.archive.as_deref() {
+                encoder.text(tag::ARTIFACT_ARCHIVE, archive);
+            }
         }
 
         let mut destinations = component.destinations.clone();
@@ -227,7 +249,11 @@ mod tests {
             authority: "registry:0.15.0".to_string(),
             kind: "executable".to_string(),
             installation_method: "prebuilt".to_string(),
-            artifacts: vec![("miden-vm".to_string(), "https://example.invalid/vm".to_string())],
+            artifacts: vec![ArtifactInput {
+                id: "miden-vm".to_string(),
+                uri: "https://example.invalid/vm".to_string(),
+                archive: None,
+            }],
             destinations: vec![("/s/bin/miden-vm".to_string(), 0o755)],
             crate_name: Some("miden-vm".to_string()),
             features: Some(vec!["std".to_string()]),
@@ -283,8 +309,12 @@ mod tests {
             ("authority", |i| i.components[0].authority = "registry:0.16.0".into()),
             ("kind", |i| i.components[0].kind = "package".into()),
             ("method", |i| i.components[0].installation_method = "cargo".into()),
-            ("artifact id", |i| i.components[0].artifacts[0].0 = "other".into()),
-            ("artifact uri", |i| i.components[0].artifacts[0].1 = "https://other".into()),
+            ("artifact id", |i| i.components[0].artifacts[0].id = "other".into()),
+            ("artifact uri", |i| i.components[0].artifacts[0].uri = "https://other".into()),
+            // Unpacking the same URI installs different bytes than fetching it whole.
+            ("artifact archive", |i| {
+                i.components[0].artifacts[0].archive = Some("tar.gz".into())
+            }),
             ("destination", |i| i.components[0].destinations[0].0 = "/s/bin/other".into()),
             ("mode", |i| i.components[0].destinations[0].1 = 0o644),
             ("crate name", |i| i.components[0].crate_name = Some("other".into())),

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -14,5 +14,5 @@ pub use self::{
         Destination, DestinationError, InvalidArtifactId, MODE_DATA, MODE_EXECUTABLE,
         destination_for, validate_artifact_id,
     },
-    key::{ComponentInputs, KeyInputs, PlanKey, compute as compute_plan_key},
+    key::{ArtifactInput, ComponentInputs, KeyInputs, PlanKey, compute as compute_plan_key},
 };

--- a/src/publish/mod.rs
+++ b/src/publish/mod.rs
@@ -293,6 +293,7 @@ mod tests {
             mode: 0o755,
             owner: "vm".to_string(),
             digest: None,
+            archive: None,
             fallback: None,
         }
     }

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -25,6 +25,8 @@ pub fn mutating_test_guard() -> MutexGuard<'static, ()> {
 
 use std::path::{Path, PathBuf};
 
+use flate2::{Compression, write::GzEncoder};
+
 /// A fully offline channel fixture: no network, no `cargo install`.
 ///
 /// Most install tests assert on *layout and state* -- which files landed where, what the symlinks
@@ -159,6 +161,63 @@ exit 0
                 }
             ]
         }));
+
+        self
+    }
+
+    /// Adds a `packages` component whose artifact is published inside a tarball.
+    ///
+    /// Built for real rather than stubbed: only genuine gzip bytes exercise the acquisition path an
+    /// archived artifact actually takes. Nested under a directory, as release tarballs are, so the
+    /// directory entry must not be mistaken for the artifact.
+    pub fn with_archived_component(mut self) -> Self {
+        use std::io::Write;
+
+        let channel = self
+            .channels
+            .last_mut()
+            .expect("with_archived_component needs a channel to add to");
+        let name = channel["name"].as_str().expect("a channel has a name").to_string();
+
+        let mut tar = tar::Builder::new(Vec::new());
+        let mut dir = tar::Header::new_gnu();
+        dir.set_entry_type(tar::EntryType::Directory);
+        dir.set_size(0);
+        dir.set_mode(0o755);
+        dir.set_path("packages-1.0/").unwrap();
+        dir.set_cksum();
+        tar.append(&dir, std::io::empty()).expect("failed to add directory");
+
+        let contents = b"archived-package";
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        tar.append_data(&mut header, "packages-1.0/archived.masp", &contents[..])
+            .expect("failed to add member");
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder
+            .write_all(&tar.into_inner().unwrap())
+            .expect("failed to compress fixture tarball");
+
+        let tarball = self.dir.join(&name).join("archived.masp.tar.gz");
+        std::fs::write(&tarball, encoder.finish().unwrap()).expect("failed to write tarball");
+
+        channel["components"].as_array_mut().expect("a channel has components").push(
+            serde_json::json!({
+                "name": "packages",
+                "version": {"kind": "registry", "version": "1.0.0"},
+                "kind": "package",
+                "profiles": ["minimal"],
+                "artifacts": {
+                    "archived.masp": {
+                        "uri": format!("file://{}", tarball.display()),
+                        "archive": "tar.gz"
+                    }
+                }
+            }),
+        );
 
         self
     }

--- a/tests/install.rs
+++ b/tests/install.rs
@@ -117,6 +117,80 @@ fn integration_install_creates_default_symlinks() {
     );
 }
 
+/// An artifact published inside a tarball installs exactly like a bare one: same destination, mode
+/// and receipt, since nothing downstream of acquisition can tell the difference.
+///
+/// The tarball nests its file under a directory, so this also shows the directory entry is not
+/// mistaken for the artifact and that nothing but the file itself reaches `lib/`.
+#[test]
+fn integration_install_unpacks_archived_artifacts() {
+    let _guard = common::harness::mutating_test_guard();
+    let test_env = environment_setup("integration_install_unpacks_archived_artifacts");
+
+    let fixture = common::harness::OfflineFixture::new(test_env.tmp_dir.path())
+        .with_channel("0.15.0")
+        .with_archived_component()
+        .build();
+    let (mut state, config) = test_setup(&test_env, &fixture.manifest_uri);
+
+    Midenup::try_parse_from(["midenup", "install", "0.15.0"])
+        .unwrap()
+        .execute_with_state(&config, &mut state)
+        .expect("failed to install");
+
+    let lib = test_env.midenup_home.join("toolchains").join("0.15.0").join("lib");
+    assert_eq!(
+        std::fs::read(lib.join("archived.masp")).unwrap(),
+        b"archived-package",
+        "the archived file must land under its artifact id"
+    );
+
+    let installed: Vec<String> = std::fs::read_dir(&lib)
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        !installed
+            .iter()
+            .any(|name| name.contains("packages-1.0") || name.ends_with(".tar.gz")),
+        "neither the container nor its directory may be installed: {installed:?}"
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            std::fs::metadata(lib.join("archived.masp")).unwrap().permissions().mode() & 0o777,
+            0o644,
+            "the mode is the planned one for a package, not the archive entry's"
+        );
+    }
+
+    let midenup::state::PublicationRef::Managed { id, .. } = &state
+        .get(&semver::Version::new(0, 15, 0))
+        .expect("the install must be recorded")
+        .publication
+    else {
+        panic!("a fresh install must produce a managed publication");
+    };
+    let publication = midenup::paths::publication_dir(
+        &test_env.midenup_home,
+        &semver::Version::new(0, 15, 0),
+        id,
+    );
+    let receipt = midenup::publish::read_receipt(&publication).expect("a receipt must be written");
+    assert!(
+        receipt
+            .outputs
+            .iter()
+            .any(|o| o.path == std::path::Path::new("lib/archived.masp")
+                && o.owner == "packages"
+                && o.realized == midenup::state::RealizedMethod::Prebuilt),
+        "an archived artifact is recorded like any other prebuilt one: {:?}",
+        receipt.outputs
+    );
+}
+
 /// An installation is published into `publications/<channel>-<publication-id>`, described by a
 /// receipt, and reached only through the `toolchains/<channel>` symlink.
 ///


### PR DESCRIPTION
Closes https://github.com/0xMiden/midenup/issues/225.

This PR:
- Introduces support for artifacts that are packaged inside a `tar.gz` file. 
- Updates the `manifest-channel.json` to re-add `cargo-miden` and `midenc` to the v0.16.0 channel since they are now supported.