### PR TITLE
docs: remove stale midenup install warning

### DIFF
--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -8,10 +8,6 @@
 cargo install midenup
 ```
 
-:::important
-Until this crate has been published to crates.io, it is only possible to install midenup by cloning the repository and then running `cargo install --path .` or `cargo install --git https://github.com/0xMiden/midenup `.
-:::
-
 2. Initialize the midenup environment:
 
 ```shell title=">_ Terminal"


### PR DESCRIPTION
Summary
Removes the old installation note that said midenup had not yet been published to crates.io.

Fixes #228.

Why
The installation guide already shows `cargo install midenup` as the default path, and midenup is now published on crates.io/docs.rs. Keeping the old warning directly below the install command makes the docs look contradictory for new users.

Changes
- Removed the stale pre-crates.io warning from `docs/src/getting-started/installation.md`.

Testing
- `git diff --check`
- `npm ci` in `docs/`
- `npm run build:dev` in `docs/`