### PR TITLE
docs: add PowerShell PATH setup steps

### DIFF
--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -80,9 +80,25 @@ If you forget to do the step above, some functionality will not work as expected
 
 ### For PowerShell (Windows)
 
-:::note todo
-Add instructions here
-:::
+Add Cargo's bin directory to your user `Path` environment variable:
+
+```powershell title=">_ Terminal"
+$cargoBin = Join-Path $HOME ".cargo\bin"
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+$paths = @($userPath -split ";" | Where-Object { $_ })
+
+if ($paths -notcontains $cargoBin) {
+    $newPath = ($paths + $cargoBin) -join ";"
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+}
+```
+
+Open a new PowerShell window so the updated `Path` is loaded, then verify the command is
+available:
+
+```powershell title=">_ Terminal"
+miden help
+```
 
 ## Install the Miden Toolchain
 


### PR DESCRIPTION
Summary
Adds the missing PowerShell instructions for putting Cargo's bin directory on the user PATH during midenup installation.

Fixes #231.

Why
The installation guide already has zsh and bash PATH setup steps, but the Windows PowerShell section was still a TODO. That leaves Windows users without the equivalent setup path after `midenup init` creates the `miden` command in Cargo's bin directory.

Changes
- Replaced the PowerShell TODO with commands that add `$HOME\.cargo\bin` to the user PATH if it is not already present.
- Added a short verification step using `miden help`.

Testing
- `git diff --check`
- `npm run build:dev` in `docs/`