### PR TITLE
feat: print progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "ascii"
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -134,9 +134,9 @@ checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -156,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.89+curl-8.20.0"
+version = "0.4.90+curl-8.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d680779285438f2d0927485973ab45b212ea990bddb80de8a55a1e3c1d9ba22"
+checksum = "97799a0d220bfb3361e0fe4936966ff8c4b24d65c3f06dfc70d7b680b44e7897"
 dependencies = [
  "cc",
  "libc",
@@ -321,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fixedbitset"
@@ -403,9 +403,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -456,15 +456,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
@@ -489,15 +489,15 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "midenup"
@@ -523,7 +523,7 @@ dependencies = [
  "tempdir",
  "thiserror",
  "tiny_http",
- "toml 1.1.2+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "upon",
 ]
 
@@ -589,24 +589,24 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -724,18 +724,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -744,9 +744,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -789,9 +789,9 @@ checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys",
@@ -805,9 +805,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -836,18 +836,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -883,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -893,7 +893,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -916,18 +916,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "typeid"
@@ -1044,12 +1044,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/docs/src/design/spec.md
+++ b/docs/src/design/spec.md
@@ -645,11 +645,12 @@ cargo [+<rustup-channel>] install --locked --profile <dev|release> [--quiet]
       --root <staging-dir>
 ```
 
-Optional arguments are omitted entirely when empty.
+Optional arguments are omitted entirely when empty. `--quiet` is present below the `verbose`
+level (§14.4), where the build's own output is suppressed.
 
 `--bin <installed-executable>` is always passed, so a multi-binary crate cannot deposit unexpected executables. After the build, the expected binary must exist at `<staging>/bin/<installed-executable>` and no unexpected binaries may have appeared; both are checked.
 
-**Package extraction** is the only remaining use of a generated Cargo script. When a plan contains `ExtractPackage` steps, `midenup` generates one script declaring the required crates as dependencies, runs it under `cargo +nightly -Zscript`, and each extractor expression writes its package to its exact `dest`. Plans with no `ExtractPackage` steps generate no script.
+**Package extraction** is the only remaining use of a generated Cargo script. When a plan contains `ExtractPackage` steps, `midenup` generates one script declaring the required crates as dependencies, runs it under `cargo +nightly -Zscript` (with the same `--quiet` rule as a build), and each extractor expression writes its package to its exact `dest`. Plans with no `ExtractPackage` steps generate no script.
 
 ### 9.4 Cargo ownership
 
@@ -1049,6 +1050,42 @@ Each variant carries the file path, the offending identifier, and a remediation 
 | `MissingDefaultNetwork(network)` | the manifest declares no `mainnet` |
 
 `DivergentState` and `NeedsReinstall` both name the exact recovery command.
+
+### 14.4 Output and verbosity
+
+**Streams.** Stdout carries a command's results; stderr carries its progress, warnings, and traces.
+
+**Levels.** Four, ordered:
+
+| Level | Flag | Emits |
+|---|---|---|
+| quiet | `-q`, `--quiet` | warnings and errors only |
+| normal | *(default)* | one line per component as it is acquired, plus a live transfer display on a terminal |
+| verbose | `-v` | the above, and the output of spawned programs is no longer suppressed |
+| debug | `-vv` | the above, and every action taken, including individual filesystem operations |
+
+Warnings and interactive prompts survive `quiet`. `verbose` and `debug` are distinct axes -
+spawned programs' output (the `--quiet` in the cargo argv, §9.3) versus `midenup`'s own actions -
+ordered on one ladder because the former is the coarser.
+
+**Where the level comes from.** The `-q`/`-v` flags, which are `midenup`'s alone; `-q` and `-v`
+together are rejected. `miden` takes no flags of its own - everything after it belongs to the
+component being dispatched to - so an install triggered by `miden` (§13) always runs at the
+default level.
+
+**What an install says.** Before the manifest fetch, that a sync is starting - the whole manifest
+is synced, so no channel is named. Then the manifest's date, the channel being installed - a
+network and the version it resolves to, or a version requested directly, named once - and the work
+ahead by kind (`3 steps: 2 downloads, 1 source build`). Then one numbered line per component and
+kind of work
+(`[2/3] building component 'x' from source`); a fallback taken mid-run (§9.3) is announced
+un-numbered, since the total was fixed before the run. After the commit point (§9.5), the channel
+that was installed.
+
+**Progress granularity.** The counter is a position in a list, never a whole-toolchain percentage:
+a source build and a package download are not comparable units. On a terminal a transient redrawn
+line shows bytes within a single transfer and elapsed time within a single build or extraction; in
+a file or CI log the announcement lines are the whole report.
 
 ---
 

--- a/docs/src/design/spec.md
+++ b/docs/src/design/spec.md
@@ -637,7 +637,6 @@ For `https` sources the destination filename comes from the **plan**, never from
 
 `Config::cargo_home` therefore governs only where the `miden` symlink is placed, which is its actual purpose.
 
-
 ```
 cargo [+<rustup-channel>] install --locked --profile <dev|release> [--quiet]
       --bin <installed-executable>
@@ -645,12 +644,11 @@ cargo [+<rustup-channel>] install --locked --profile <dev|release> [--quiet]
       --root <staging-dir>
 ```
 
-Optional arguments are omitted entirely when empty. `--quiet` is present below the `verbose`
-level (§14.4), where the build's own output is suppressed.
+Optional arguments are omitted entirely when empty.
 
 `--bin <installed-executable>` is always passed, so a multi-binary crate cannot deposit unexpected executables. After the build, the expected binary must exist at `<staging>/bin/<installed-executable>` and no unexpected binaries may have appeared; both are checked.
 
-**Package extraction** is the only remaining use of a generated Cargo script. When a plan contains `ExtractPackage` steps, `midenup` generates one script declaring the required crates as dependencies, runs it under `cargo +nightly -Zscript` (with the same `--quiet` rule as a build), and each extractor expression writes its package to its exact `dest`. Plans with no `ExtractPackage` steps generate no script.
+**Package extraction** is the only remaining use of a generated Cargo script. When a plan contains `ExtractPackage` steps, `midenup` generates one script declaring the required crates as dependencies, runs it under `cargo +nightly -Zscript`, and each extractor expression writes its package to its exact `dest`. Plans with no `ExtractPackage` steps generate no script.
 
 ### 9.4 Cargo ownership
 
@@ -1060,9 +1058,9 @@ Each variant carries the file path, the offending identifier, and a remediation 
 | Level | Flag | Emits |
 |---|---|---|
 | quiet | `-q`, `--quiet` | warnings and errors only |
-| normal | *(default)* | one line per component as it is acquired, plus a live transfer display on a terminal |
+| normal | *(default)* | one line per unit of work as it happens |
 | verbose | `-v` | the above, and the output of spawned programs is no longer suppressed |
-| debug | `-vv` | the above, and every action taken, including individual filesystem operations |
+| debug | `-vv` | the above, and the individual actions taken: fetches, spawned commands, seeded files, symlink commits, link updates, record writes, deletions |
 
 Warnings and interactive prompts survive `quiet`. `verbose` and `debug` are distinct axes -
 spawned programs' output (the `--quiet` in the cargo argv, §9.3) versus `midenup`'s own actions -

--- a/src/commands/gc.rs
+++ b/src/commands/gc.rs
@@ -21,14 +21,14 @@ pub fn gc(config: &Config, state: &LocalState) -> anyhow::Result<()> {
     }
 
     for orphan in &orphans {
-        println!("removing {}", orphan.display());
+        crate::info!("removing {}", orphan.display());
         std::fs::remove_dir_all(orphan)
             .with_context(|| format!("failed to remove '{}'", orphan.display()))?;
     }
 
     println!(
         "reclaimed {} {}",
-        orphans.len().to_string().white().bold(),
+        orphans.len().to_string().bold(),
         if orphans.len() == 1 {
             "publication"
         } else {

--- a/src/commands/gc.rs
+++ b/src/commands/gc.rs
@@ -16,7 +16,7 @@ pub fn gc(config: &Config, state: &LocalState) -> anyhow::Result<()> {
     let orphans = crate::publish::unreferenced(&config.midenup_home, state)?;
 
     if orphans.is_empty() {
-        println!("nothing to reclaim");
+        crate::info!("nothing to reclaim");
         return Ok(());
     }
 
@@ -26,7 +26,7 @@ pub fn gc(config: &Config, state: &LocalState) -> anyhow::Result<()> {
             .with_context(|| format!("failed to remove '{}'", orphan.display()))?;
     }
 
-    println!(
+    crate::info!(
         "reclaimed {} {}",
         orphans.len().to_string().bold(),
         if orphans.len() == 1 {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -144,9 +144,8 @@ pub fn setup_midenup(config: &Config) -> Result<InitializationState, Initializat
                 state = InitializationState::Initialized;
             }
 
-            println!(
-                "
-Could not find `miden` executable in the system's PATH.
+            crate::warn!(
+                "could not find the `miden` executable in the system's PATH.
 
 The `miden` symlink was placed in $CARGO_HOME/bin ({cargo_bin_display}), which should already be \
                  in your PATH if you have Rust installed. If not, ensure $CARGO_HOME/bin is in \

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -23,12 +23,15 @@ pub fn init(config: &Config) -> Result<(), InitializationError> {
     let state = setup_midenup(config)?;
 
     match state {
-        InitializationState::Initialized => println!(
+        InitializationState::Initialized => crate::info!(
             "midenup was successfully initialized in: {}",
             config.midenup_home.as_path().display()
         ),
         InitializationState::AlreadyInitialized => {
-            println!("midenup already initialized in: {}", config.midenup_home.as_path().display())
+            crate::info!(
+                "midenup already initialized in: {}",
+                config.midenup_home.as_path().display()
+            )
         },
     }
 

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -156,6 +156,7 @@ pub fn install(
         }
 
         let link = paths::network_link(home, network);
+        crate::trace!("linking {} -> {}", link.display(), relative_channel_target.display());
         utils::fs::replace_symlink(&link, &relative_channel_target).with_context(|| {
             format!("failed to point '{network}' at the newly installed channel")
         })?;

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -80,7 +80,12 @@ pub fn install(
         )?;
     }
 
-    let realized = crate::install::execute(&plan, &publication, options.verbose, config.debug)?;
+    let realized = crate::install::execute(
+        &plan,
+        &publication,
+        crate::report::subprocess_output_visible(),
+        config.debug,
+    )?;
 
     // Spec section 9.2: a `path` source that moves *during* the build produces an installation
     // matching neither the tree we pinned nor the one on disk now, and nothing else would ever
@@ -160,6 +165,8 @@ pub fn install(
     // 7. CLEAN.
     crate::publish::journal::clean(home, &entry)?;
 
+    crate::info!("installed channel '{}'", channel.name);
+
     Ok(())
 }
 
@@ -236,15 +243,12 @@ fn carry_migrated_intent(state: &LocalState, channel: &Channel, intent: Intent) 
         return intent;
     }
 
-    println!(
-        "{}: these components are no longer part of channel {} and have been dropped from your \
-         selection:",
-        "warning".yellow().bold(),
+    let listed = dropped.iter().map(|root| format!("\n- {}", root.bold())).collect::<String>();
+    crate::warn!(
+        "these components are no longer part of channel {} and have been dropped from your \
+         selection:{listed}",
         channel.name
     );
-    for root in &dropped {
-        println!("- {}", root.white().bold());
-    }
 
     Intent {
         profiles: intent.profiles,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -24,7 +24,7 @@ pub use self::{
     uninstall::uninstall,
     update::update,
 };
-use crate::{channel, config, manifest, options};
+use crate::{channel, config, manifest, options, report};
 
 pub const MIDENUP_MANIFEST_URI_ENV: &str = "MIDENUP_MANIFEST_URI";
 
@@ -77,14 +77,24 @@ struct GlobalArgs {
         default_value = manifest::VersionedManifest::PUBLISHED_MANIFEST_URI
     )]
     pub manifest_uri: String,
-    /// Determines wether the components are installed in debug mode. Useful for
-    /// debugging and faster installations. This flag is only avaialble to
-    /// `midenup`, not `miden`.
-    #[arg(env = "MIDENUP_DEBUG_MODE", action = ArgAction::Set, default_value = "false", hide = true)]
+    /// Determines whether the components are installed in debug mode. Useful for debugging and
+    /// faster installations. This flag is only available to `midenup`, not `miden`.
+    #[arg(long, env = "MIDENUP_DEBUG_MODE", hide = true)]
     pub debug: bool,
-    /// Display verbose output, mainly used during install.
-    #[arg(short, long, action, default_value_t = false)]
-    pub verbose: bool,
+    /// Suppress progress and informational output. Warnings and errors are still shown.
+    #[arg(
+        short,
+        long,
+        global = true,
+        action,
+        default_value_t = false,
+        conflicts_with = "verbose"
+    )]
+    pub quiet: bool,
+    /// Report more: `-v` also shows the output of the programs midenup runs, `-vv` traces every
+    /// action it takes.
+    #[arg(short, long, global = true, action = ArgAction::Count)]
+    pub verbose: u8,
     /// Displays `midenup`'s version information.
     #[arg(short = 'V', long, action, default_value_t = false)]
     pub version: bool,
@@ -196,7 +206,11 @@ impl Commands {
             Self::Gc => gc(config, state),
             Self::List => list(config, state),
             Self::Install { channel, options } => {
+                // Said before the fetch it describes, which is what can hang on a slow network.
+                // The whole manifest is synced, so no channel is named here.
+                crate::info!("syncing channel updates from upstream");
                 let manifest = config.upstream_manifest()?;
+                let requested = channel;
                 let Some(channel) = manifest.get_channel(channel) else {
                     // Which names exist is manifest data now, so a typo has to be answerable with
                     // what was actually declared rather than "doesn't exist or is unavailable".
@@ -210,6 +224,17 @@ impl Commands {
                         },
                     }
                 };
+
+                // A network resolves to a version, and both halves are worth stating; a version
+                // requested directly is only worth stating once.
+                let target = if requested.to_string() == channel.name.to_string() {
+                    channel.name.to_string()
+                } else {
+                    format!("{requested} ({})", channel.name)
+                };
+                crate::info!("upstream last updated on {}", manifest.last_updated());
+                crate::info!("installing {target}");
+
                 install(config, channel, state, options)
             },
             // Deliberately not resolved against upstream: a channel that has been withdrawn is
@@ -226,6 +251,10 @@ impl Commands {
 impl Midenup {
     /// Get the effective configuration for the current session
     pub fn config(&self) -> anyhow::Result<config::Config> {
+        // Before anything that could report: this governs the first message emitted, and the
+        // migrations below are reached before any command runs.
+        crate::report::set(self.verbosity());
+
         let working_directory =
             std::env::current_dir().context("unable to read current directory")?;
         match &self.behavior {
@@ -330,6 +359,19 @@ impl Midenup {
         }
     }
 
+    /// The verbosity in effect for this session.
+    ///
+    /// `miden` takes no flags of its own -- everything after it belongs to the component being
+    /// dispatched to -- so an install it triggers always runs at the default level.
+    fn verbosity(&self) -> report::Verbosity {
+        match &self.behavior {
+            Behavior::Miden(_) => report::Verbosity::default(),
+            Behavior::Midenup { config, .. } => {
+                report::Verbosity::resolve(config.quiet, config.verbose)
+            },
+        }
+    }
+
     /// Execute this session with the provided configuration.
     pub fn execute(&self, config: &config::Config) -> anyhow::Result<()> {
         let mut state = config.local_state()?;
@@ -397,15 +439,12 @@ impl Midenup {
 }
 
 fn report_migration(channels: &[semver::Version]) {
-    use colored::Colorize;
-
-    println!(
-        "{}: migrated {} installed toolchain(s) to the new local state format",
-        "info".white().bold(),
+    crate::info!(
+        "migrated {} installed toolchain(s) to the new local state format",
         channels.len()
     );
     for channel in channels {
-        println!(
+        crate::note!(
             "- {channel} will be reinstalled the next time it is used, so that midenup knows \
              exactly what it owns"
         );
@@ -423,8 +462,6 @@ fn report_migration(channels: &[semver::Version]) {
 /// would leave the user with a diagnostic they cannot act on. The operation that actually needs
 /// the missing files fails on its own terms.
 fn recover(config: &config::Config, state: &mut crate::state::LocalState) -> anyhow::Result<()> {
-    use colored::Colorize;
-
     // Recovery mutates, so it takes the lock -- but only when there is something to recover.
     // Taking it unconditionally would put every `miden` invocation behind it, and the read-only
     // dispatch path is required to stay lock-free.
@@ -441,10 +478,10 @@ fn recover(config: &config::Config, state: &mut crate::state::LocalState) -> any
     match crate::publish::journal::recover(&config.midenup_home, state) {
         Ok(None) => {},
         Ok(Some(operation)) => {
-            println!("{}: recovered an interrupted {operation}", "info".white().bold());
+            crate::info!("recovered an interrupted {operation}");
         },
         Err(err @ crate::publish::PublishError::DivergentState { .. }) => {
-            eprintln!("{}: {err}", "warning".yellow().bold());
+            crate::warn!("{err}");
         },
         Err(err) => return Err(err.into()),
     }
@@ -463,4 +500,22 @@ fn get_full_command(argv: &[OsString]) -> String {
         write!(&mut out, "{}", arg.display()).unwrap();
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use super::*;
+
+    #[test]
+    fn a_mistyped_subcommand_names_the_word_that_was_mistyped() {
+        let err = Midenup::try_parse_from(["midenup", "instal", "stable"])
+            .expect_err("a mistyped subcommand must not parse");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("instal"),
+            "the typo itself must be named, not the word after it: {rendered}"
+        );
+    }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -206,9 +206,6 @@ impl Commands {
             Self::Gc => gc(config, state),
             Self::List => list(config, state),
             Self::Install { channel, options } => {
-                // Said before the fetch it describes, which is what can hang on a slow network.
-                // The whole manifest is synced, so no channel is named here.
-                crate::info!("syncing channel updates from upstream");
                 let manifest = config.upstream_manifest()?;
                 let requested = channel;
                 let Some(channel) = manifest.get_channel(channel) else {
@@ -232,7 +229,6 @@ impl Commands {
                 } else {
                     format!("{requested} ({})", channel.name)
                 };
-                crate::info!("upstream last updated on {}", manifest.last_updated());
                 crate::info!("installing {target}");
 
                 install(config, channel, state, options)

--- a/src/commands/override.rs
+++ b/src/commands/override.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, bail};
-use colored::Colorize;
 
 use crate::{
     channel::UserChannel,
@@ -76,13 +75,12 @@ pub fn r#override(
             .context("failed to remove 'default' toolchain symlink")?;
     }
 
-    println!("{}: setting {channel} as the new default toolchain\n", "info".white().bold());
+    crate::info!("setting {channel} as the new default toolchain\n");
     if let ToolchainJustification::MidenToolchainFile { path } = justification {
-        println!(
-            "{}: there is a toolchain file present in {}, which sets the current active toolchain \
-             to be {}.
+        crate::warn!(
+            "there is a toolchain file present in {}, which sets the current active toolchain to \
+             be {}.
 This will take prescedence over the configuration done by `midenup override`.",
-            "warn".yellow(),
             path.display(),
             active.channel
         );

--- a/src/commands/set.rs
+++ b/src/commands/set.rs
@@ -29,5 +29,7 @@ pub fn set(config: &Config, channel: &UserChannel) -> anyhow::Result<()> {
     toolchain_file
         .write_all(&toolchain_file_contents.into_bytes())
         .context("failed to write miden-toolchain.toml")?;
+
+    crate::info!("wrote {TOOLCHAIN_FILE_NAME}: this directory now uses {channel}");
     Ok(())
 }

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -11,8 +11,6 @@ use crate::{
 #[derive(Debug, Subcommand)]
 pub enum ShowCommand {
     /// Show the active toolchain.
-    ///
-    /// Reports the channel alone; `-v` also reports why it is the active one.
     #[command(name = "active-toolchain")]
     Current,
     /// Display the computed value of MIDENUP_HOME
@@ -27,32 +25,26 @@ impl ShowCommand {
             Self::Current => {
                 let (toolchain, justification) = Toolchain::current(config, None)?;
 
-                if report::verbosity() < report::Verbosity::Verbose {
-                    println!("{}", toolchain.channel);
-                } else {
+                // The justification is commentary, not the result, so it goes to stderr.
+                if report::verbosity() >= report::Verbosity::Verbose {
                     match justification {
                         ToolchainJustification::MidenToolchainFile { path } => {
-                            println!(
-                                "{}: found a miden-toolchain.toml file in {}",
-                                "info".bold(),
-                                path.display()
-                            )
+                            crate::info!("found a miden-toolchain.toml file in {}", path.display())
                         },
                         ToolchainJustification::Override => {
-                            println!(
-                                "{}: system default has been overridden via `midenup override`",
-                                "info".bold(),
+                            crate::info!(
+                                "system default has been overridden via `midenup override`"
                             )
                         },
                         ToolchainJustification::Requested => {
-                            println!("{}: explicitly requested by user", "info".bold(),)
+                            crate::info!("explicitly requested by user")
                         },
                         ToolchainJustification::Default => {
-                            println!("{}: current toolchain is system default", "info".bold());
+                            crate::info!("current toolchain is system default")
                         },
                     }
-                    println!("The current active toolchain is {}", toolchain.channel);
                 }
+                println!("{}", toolchain.channel);
 
                 Ok(())
             },

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -3,18 +3,18 @@ use colored::Colorize;
 
 use crate::{
     config::Config,
+    report,
     state::LocalState,
     toolchain::{Toolchain, ToolchainJustification},
 };
 
 #[derive(Debug, Subcommand)]
 pub enum ShowCommand {
-    /// Show the active toolchain
+    /// Show the active toolchain.
+    ///
+    /// Reports the channel alone; `-v` also reports why it is the active one.
     #[command(name = "active-toolchain")]
-    Current {
-        #[arg(long, action)]
-        verbose: bool,
-    },
+    Current,
     /// Display the computed value of MIDENUP_HOME
     Home,
     /// List installed toolchains
@@ -24,34 +24,31 @@ pub enum ShowCommand {
 impl ShowCommand {
     pub fn execute(&self, config: &Config, state: &LocalState) -> anyhow::Result<()> {
         match self {
-            Self::Current { verbose } => {
+            Self::Current => {
                 let (toolchain, justification) = Toolchain::current(config, None)?;
 
-                if !verbose {
+                if report::verbosity() < report::Verbosity::Verbose {
                     println!("{}", toolchain.channel);
                 } else {
                     match justification {
                         ToolchainJustification::MidenToolchainFile { path } => {
                             println!(
                                 "{}: found a miden-toolchain.toml file in {}",
-                                "info".white().bold(),
+                                "info".bold(),
                                 path.display()
                             )
                         },
                         ToolchainJustification::Override => {
                             println!(
                                 "{}: system default has been overridden via `midenup override`",
-                                "info".white().bold(),
+                                "info".bold(),
                             )
                         },
                         ToolchainJustification::Requested => {
-                            println!("{}: explicitly requested by user", "info".white().bold(),)
+                            println!("{}: explicitly requested by user", "info".bold(),)
                         },
                         ToolchainJustification::Default => {
-                            println!(
-                                "{}: current toolchain is system default",
-                                "info".white().bold()
-                            );
+                            println!("{}: current toolchain is system default", "info".bold());
                         },
                     }
                     println!("The current active toolchain is {}", toolchain.channel);

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, bail};
-use colored::Colorize;
 
 use crate::{
     channel::UserChannel,
@@ -86,10 +85,9 @@ pub fn uninstall(
     let default = paths::toolchains_dir(home).join("default");
     if std::fs::symlink_metadata(&default).is_ok() && default.canonicalize().is_err() {
         std::fs::remove_file(&default)?;
-        println!(
-            "{}: removed the 'default' override, which named {channel}. Set a new one with:\n    \
-             midenup override <channel>",
-            "info".white().bold()
+        crate::info!(
+            "removed the 'default' override, which named {channel}. Set a new one with:\n    \
+             midenup override <channel>"
         );
     }
 
@@ -105,7 +103,7 @@ pub fn uninstall(
             std::fs::remove_dir_all(&var)
                 .with_context(|| format!("failed to remove '{}'", var.display()))?;
         } else {
-            println!(
+            crate::info!(
                 "kept your data for {requested} at {}; remove it with `midenup uninstall \
                  {requested} --purge`",
                 var.display()

--- a/src/commands/uninstall.rs
+++ b/src/commands/uninstall.rs
@@ -68,7 +68,9 @@ pub fn uninstall(
     // never actually removed -- which is why `default` is handled after the commit instead.
     for (network, linked) in crate::networks::links(home) {
         if linked == channel {
-            std::fs::remove_file(paths::network_link(home, &network))?;
+            let link = paths::network_link(home, &network);
+            crate::trace!("removing {}", link.display());
+            std::fs::remove_file(link)?;
         }
     }
 
@@ -100,6 +102,7 @@ pub fn uninstall(
     let var = paths::var_dir(home, requested);
     if var.is_dir() {
         if purge {
+            crate::trace!("removing {}", var.display());
             std::fs::remove_dir_all(&var)
                 .with_context(|| format!("failed to remove '{}'", var.display()))?;
         } else {
@@ -110,6 +113,8 @@ pub fn uninstall(
             );
         }
     }
+
+    crate::info!("uninstalled channel '{channel}'");
 
     Ok(())
 }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -27,6 +27,12 @@ pub fn update(
     state: &mut LocalState,
     options: &UpdateOptions,
 ) -> anyhow::Result<()> {
+    // Said before the fetch it describes; the whole manifest is synced, whichever channel was
+    // asked about, so no channel is named here.
+    crate::info!("syncing channel updates from upstream");
+    let manifest = config.upstream_manifest()?;
+    crate::info!("upstream last updated on {}", manifest.last_updated());
+
     match channel_type {
         Some(UserChannel::Named(name)) => update_network(config, name, state, options),
         Some(UserChannel::Version(version)) => {
@@ -35,13 +41,15 @@ pub fn update(
                 .cloned()
                 .context(format!("ERROR: No installed channel found with version {version}"))?;
 
-            crate::info!("syncing channel updates for {}", installation.channel);
             update_installed_channel(config, &installation, state, options)
         },
         None => {
+            if state.installations.is_empty() {
+                println!("nothing to update: no toolchains are installed");
+                return Ok(());
+            }
             // Update everything installed. Cloned up front because each update writes state.
             for installation in state.installations.clone() {
-                crate::info!("syncing channel updates for {}", installation.channel);
                 update_installed_channel(config, &installation, state, options)?;
             }
             Ok(())
@@ -89,8 +97,7 @@ fn update_network(
         )
     })?;
 
-    crate::info!("syncing channel updates for {name} (installed as {installed})");
-    crate::info!("{name} is now {target} (upstream last updated on {})", manifest.last_updated());
+    crate::info!("{name} is now {target} (installed as {installed})");
 
     if installed == target {
         // The pointer has not moved, which does not mean there is nothing to do: the channel's own
@@ -195,10 +202,12 @@ fn update_installed_channel(
         // A bit of an edge case. The channel is installed but absent upstream, so it is either a
         // developer toolchain or something that was withdrawn; either way there is nothing to
         // reconcile it against.
+        println!(
+            "channel {} is not in the upstream manifest; leaving it as installed",
+            installation.channel
+        );
         return Ok(());
     };
-
-    crate::info!("upstream last updated on {}", config.upstream_manifest()?.last_updated());
 
     match migration_of(&upstream, installation) {
         Some(old_channel) => migrate(config, installation, &upstream.channel, state, options)

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -35,13 +35,13 @@ pub fn update(
                 .cloned()
                 .context(format!("ERROR: No installed channel found with version {version}"))?;
 
-            println!("syncing channel updates for {}", installation.channel);
+            crate::info!("syncing channel updates for {}", installation.channel);
             update_installed_channel(config, &installation, state, options)
         },
         None => {
             // Update everything installed. Cloned up front because each update writes state.
             for installation in state.installations.clone() {
-                println!("syncing channel updates for {}", installation.channel);
+                crate::info!("syncing channel updates for {}", installation.channel);
                 update_installed_channel(config, &installation, state, options)?;
             }
             Ok(())
@@ -89,8 +89,8 @@ fn update_network(
         )
     })?;
 
-    println!("syncing channel updates for {name} (installed as {installed})");
-    println!("{name} is now {target} (upstream last updated on {})", manifest.last_updated());
+    crate::info!("syncing channel updates for {name} (installed as {installed})");
+    crate::info!("{name} is now {target} (upstream last updated on {})", manifest.last_updated());
 
     if installed == target {
         // The pointer has not moved, which does not mean there is nothing to do: the channel's own
@@ -103,10 +103,7 @@ fn update_network(
     })?;
 
     if target < installed {
-        eprintln!(
-            "{}: {name} has moved back from {installed} to {target}.",
-            "warning".yellow().bold(),
-        );
+        crate::warn!("{name} has moved back from {installed} to {target}.");
     }
 
     upstream.sync(config);
@@ -201,7 +198,7 @@ fn update_installed_channel(
         return Ok(());
     };
 
-    println!("upstream last updated on {}", config.upstream_manifest()?.last_updated());
+    crate::info!("upstream last updated on {}", config.upstream_manifest()?.last_updated());
 
     match migration_of(&upstream, installation) {
         Some(old_channel) => migrate(config, installation, &upstream.channel, state, options)
@@ -209,7 +206,7 @@ fn update_installed_channel(
         None => {
             let Some(changes) = changes_for(config, installation, &upstream.channel, options)?
             else {
-                println!(
+                crate::info!(
                     "Aborting update of {} due to user input/configuration",
                     installation.channel
                 );
@@ -255,12 +252,7 @@ fn migrate(
     state: &mut LocalState,
     options: &UpdateOptions,
 ) -> anyhow::Result<()> {
-    println!(
-        "{}: migrating {} to {}",
-        "warning".yellow().bold(),
-        installation.channel,
-        upstream.name
-    );
+    crate::warn!("migrating {} to {}", installation.channel, upstream.name);
 
     install_for_update(
         config,
@@ -342,7 +334,6 @@ fn install_for_update(
 ) -> anyhow::Result<()> {
     let logical_only = changes.logical_only;
     let install_options = InstallationOptions {
-        verbose: options.verbose,
         stale: changes.stale,
         held_back: changes.held_back,
         intent_update: Some(intent_update),
@@ -352,14 +343,14 @@ fn install_for_update(
     match work_for(upstream, state, &install_options, logical_only)? {
         Work::Physical => {
             display_warnings(upstream, &install_options, options);
-            println!("Updating toolchain {}..", upstream.name);
+            crate::info!("Updating toolchain {}..", upstream.name);
             commands::install(config, upstream, state, &install_options)
         },
         // Spec section 9.8: a change that touches selection or runtime metadata but no installed
         // file is committed as a single atomic `state.json` write. No journal, no staging, no new
         // publication -- republishing an identical tree to record an alias would be pure cost.
         Work::LogicalOnly => {
-            println!("Updating recorded metadata for toolchain {}..", upstream.name);
+            crate::info!("Updating recorded metadata for toolchain {}..", upstream.name);
             record_logical_changes(config, upstream, state, &install_options)
         },
         Work::Nothing => {
@@ -464,10 +455,9 @@ fn carry_var_to(home: &Path, from: &semver::Version, to: &semver::Version) -> an
         return Ok(());
     }
     if destination.exists() {
-        eprintln!(
-            "{}: var/{from} was left in place: you already have data at var/{to}, and the two are \
-             not merged.",
-            "warning".yellow().bold(),
+        crate::warn!(
+            "var/{from} was left in place: you already have data at var/{to}, and the two are not \
+             merged."
         );
         return Ok(());
     }
@@ -566,22 +556,21 @@ fn display_warnings(
         return;
     }
 
-    println!(
-        "\n{}: The following elements are installed from a specific path in the filesystem.",
-        "WARNING".yellow().bold(),
-    );
-
-    if matches!(options.path_update, PathUpdate::Off) && !install_options.held_back.is_empty() {
-        println!(
-            "
+    let guidance = if matches!(options.path_update, PathUpdate::Off)
+        && !install_options.held_back.is_empty()
+    {
+        "
 To make midenup update them all, pass the '--path-update=all' flag to `midenup update`.
 Alternatively, pass the '--path-update=interactive' flag to interactively select which \
-             path-managed components to update.",
-        );
-    }
-    for component_message in components_from_path {
-        println!("{}", component_message);
-    }
+         path-managed components to update."
+    } else {
+        ""
+    };
+    let listed = components_from_path.concat();
+    crate::warn!(
+        "the following elements are installed from a specific path in the filesystem.{guidance}
+{listed}"
+    );
 }
 
 #[cfg(test)]

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -27,11 +27,8 @@ pub fn update(
     state: &mut LocalState,
     options: &UpdateOptions,
 ) -> anyhow::Result<()> {
-    // Said before the fetch it describes; the whole manifest is synced, whichever channel was
-    // asked about, so no channel is named here.
-    crate::info!("syncing channel updates from upstream");
-    let manifest = config.upstream_manifest()?;
-    crate::info!("upstream last updated on {}", manifest.last_updated());
+    // Sync up front, so the header precedes any per-channel work; later calls hit the cache.
+    config.upstream_manifest()?;
 
     match channel_type {
         Some(UserChannel::Named(name)) => update_network(config, name, state, options),
@@ -45,7 +42,7 @@ pub fn update(
         },
         None => {
             if state.installations.is_empty() {
-                println!("nothing to update: no toolchains are installed");
+                crate::info!("nothing to update: no toolchains are installed");
                 return Ok(());
             }
             // Update everything installed. Cloned up front because each update writes state.
@@ -202,7 +199,7 @@ fn update_installed_channel(
         // A bit of an edge case. The channel is installed but absent upstream, so it is either a
         // developer toolchain or something that was withdrawn; either way there is nothing to
         // reconcile it against.
-        println!(
+        crate::info!(
             "channel {} is not in the upstream manifest; leaving it as installed",
             installation.channel
         );
@@ -363,7 +360,7 @@ fn install_for_update(
             record_logical_changes(config, upstream, state, &install_options)
         },
         Work::Nothing => {
-            println!("Toolchain {} is up to date", upstream.name);
+            crate::info!("Toolchain {} is up to date", upstream.name);
             Ok(())
         },
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,6 @@ use std::{
 };
 
 use anyhow::Context;
-use colored::Colorize;
 
 use crate::{
     channel::Channel,
@@ -154,9 +153,9 @@ impl Config {
 
         match cached {
             Ok(manifest) => {
-                eprintln!(
-                    "{}: could not reach '{}' ({fetch_error}); using the cached manifest from                      '{}', which may be out of date",
-                    "warning".yellow().bold(),
+                crate::warn!(
+                    "could not reach '{}' ({fetch_error}); using the cached manifest from '{}', \
+                     which may be out of date",
                     self.manifest_uri,
                     cache.display(),
                 );

--- a/src/config.rs
+++ b/src/config.rs
@@ -139,6 +139,7 @@ impl Config {
                 Ok(manifest) => {
                     // Best effort: a manifest we could not cache is still a manifest we can use.
                     let _ = std::fs::create_dir_all(&self.midenup_home);
+                    crate::trace!("caching the manifest at {}", cache.display());
                     let _ = std::fs::write(&cache, &contents);
                     return Ok(manifest);
                 },

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,10 +128,12 @@ impl Config {
         }
 
         let manifest = self.fetch_upstream_manifest()?;
+        crate::info!("upstream last updated on {}", manifest.last_updated());
         Ok(self.manifest.get_or_init(|| manifest))
     }
 
     fn fetch_upstream_manifest(&self) -> anyhow::Result<Manifest> {
+        crate::info!("syncing channel updates from upstream");
         let cache = crate::paths::manifest_cache(&self.midenup_home);
 
         let fetch_error = match VersionedManifest::read_from(&self.manifest_uri) {

--- a/src/install/cargo.rs
+++ b/src/install/cargo.rs
@@ -60,7 +60,10 @@ pub fn build(
     verbose: bool,
     debug: bool,
 ) -> Result<(), CargoError> {
-    let PlanStep::CargoBuild { crate_name, expect_binary, dest, .. } = step else {
+    let PlanStep::CargoBuild {
+        crate_name, expect_binary, dest, owner, ..
+    } = step
+    else {
         return Ok(());
     };
 
@@ -76,11 +79,15 @@ pub fn build(
         .collect::<Vec<_>>()
         .join(" ");
 
-    let status = std::process::Command::new("cargo")
+    crate::trace!("running: cargo {rendered}");
+
+    let mut command = std::process::Command::new("cargo");
+    command
         .args(&argv)
         .stderr(std::process::Stdio::inherit())
-        .stdout(std::process::Stdio::inherit())
-        .status()
+        .stdout(std::process::Stdio::inherit());
+
+    let status = crate::install::run_reporting_progress(&mut command, owner)
         .map_err(|err| CargoError::Spawn(err.to_string()))?;
 
     if !status.success() {

--- a/src/install/download.rs
+++ b/src/install/download.rs
@@ -19,6 +19,7 @@
 //! the bytes it came out of, and the container is never written anywhere.
 
 use std::{
+    cell::RefCell,
     io::Write,
     path::{Path, PathBuf},
 };
@@ -27,6 +28,7 @@ use crate::{
     artifact::SupportedFormat,
     install::{ArchiveError, archive},
     plan::PlanStep,
+    report,
 };
 
 /// How many redirects to follow before giving up.
@@ -72,7 +74,9 @@ pub enum ExecError {
 /// Cargo executor. Every path is taken verbatim from the plan.
 pub fn acquire(step: &PlanStep) -> Result<(), ExecError> {
     match step {
-        PlanStep::Download { uri, dest, mode, archive, .. } => download(uri, dest, *mode, *archive),
+        PlanStep::Download { uri, dest, mode, archive, owner, .. } => {
+            download(uri, dest, *mode, *archive, owner)
+        },
         PlanStep::CopyLocal { src, dest, mode, archive, .. } => {
             copy_local(src, dest, *mode, *archive)
         },
@@ -81,13 +85,17 @@ pub fn acquire(step: &PlanStep) -> Result<(), ExecError> {
 }
 
 /// Fetches `uri` to `dest`, atomically, unpacking it first when it is an archive.
+///
+/// `label` names what is being transferred for the progress display; it is the owning component,
+/// never anything derived from the URL.
 pub fn download(
     uri: &str,
     dest: &Path,
     mode: u32,
     archive: Option<SupportedFormat>,
+    label: &str,
 ) -> Result<(), ExecError> {
-    let body = fetch(uri)?;
+    let body = fetch(uri, label)?;
     publish(&body, archive, uri, dest, mode)
 }
 
@@ -108,7 +116,7 @@ pub fn copy_local(
 }
 
 /// Retrieves `uri`, rejecting anything that is not a usable body.
-fn fetch(uri: &str) -> Result<Vec<u8>, ExecError> {
+fn fetch(uri: &str, label: &str) -> Result<Vec<u8>, ExecError> {
     let mut body = Vec::new();
     let mut handle = curl::easy::Easy::new();
 
@@ -116,6 +124,8 @@ fn fetch(uri: &str) -> Result<Vec<u8>, ExecError> {
         handle.url(uri)?;
         handle.follow_location(true)?;
         handle.max_redirections(MAX_REDIRECTS)?;
+        // Without this curl never calls the progress function at all.
+        handle.progress(true)?;
         Ok(())
     };
     setup(&mut handle).map_err(|err| ExecError::Transfer {
@@ -123,12 +133,30 @@ fn fetch(uri: &str) -> Result<Vec<u8>, ExecError> {
         reason: err.description().to_string(),
     })?;
 
+    crate::trace!("GET {uri}");
+
+    // Shared with the progress callback below, which runs while `write_function` also holds a
+    // borrow of `body`. Dropped at the end of this scope, which erases the display whether the
+    // transfer succeeded or failed.
+    let progress = RefCell::new(report::Transfer::begin(label));
+
     {
         let mut transfer = handle.transfer();
         transfer
             .write_function(|chunk| {
                 body.extend_from_slice(chunk);
                 Ok(chunk.len())
+            })
+            .map_err(|err| ExecError::Transfer {
+                uri: uri.to_string(),
+                reason: err.description().to_string(),
+            })?;
+        transfer
+            .progress_function(|total, done, _, _| {
+                // A server that sends no Content-Length reports a total of zero, which the display
+                // reads as "count what has arrived and claim no denominator".
+                progress.borrow_mut().update(done as u64, total as u64);
+                true
             })
             .map_err(|err| ExecError::Transfer {
                 uri: uri.to_string(),
@@ -201,6 +229,7 @@ fn publish(
         return Err(err);
     }
 
+    crate::trace!("publishing {} -> {}", temporary.display(), dest.display());
     if let Err(source) = std::fs::rename(&temporary, dest) {
         let _ = std::fs::remove_file(&temporary);
         return Err(ExecError::Publish { dest: dest.to_path_buf(), source });
@@ -314,7 +343,8 @@ mod tests {
         let dir = temp();
         let dest = dir.path().join("artifact.bin");
 
-        let err = download(&server.url("/x"), &dest, 0o755, None).expect_err("a 404 must fail");
+        let err = download(&server.url("/x"), &dest, 0o755, None, "fixture")
+            .expect_err("a 404 must fail");
         assert!(matches!(err, ExecError::HttpStatus { status: 404, .. }), "{err}");
         assert!(!dest.exists(), "a failed download must not leave a file");
         assert!(leftovers(dir.path(), "artifact.bin").is_empty(), "no partial files");
@@ -326,7 +356,8 @@ mod tests {
         let dir = temp();
         let dest = dir.path().join("a.bin");
 
-        let err = download(&server.url("/x"), &dest, 0o755, None).expect_err("a 500 must fail");
+        let err = download(&server.url("/x"), &dest, 0o755, None, "fixture")
+            .expect_err("a 500 must fail");
         assert!(matches!(err, ExecError::HttpStatus { status: 500, .. }), "{err}");
         assert!(!dest.exists());
     }
@@ -338,8 +369,8 @@ mod tests {
         let dir = temp();
         let dest = dir.path().join("a.bin");
 
-        let err =
-            download(&server.url("/x"), &dest, 0o755, None).expect_err("an empty body must fail");
+        let err = download(&server.url("/x"), &dest, 0o755, None, "fixture")
+            .expect_err("an empty body must fail");
         assert!(matches!(err, ExecError::EmptyBody { .. }), "{err}");
         assert!(!dest.exists());
     }
@@ -350,7 +381,7 @@ mod tests {
         let dir = temp();
         let dest = dir.path().join("planned-name.bin");
 
-        download(&server.url("/x"), &dest, 0o755, None).expect("should succeed");
+        download(&server.url("/x"), &dest, 0o755, None, "fixture").expect("should succeed");
         assert_eq!(std::fs::read(&dest).unwrap(), b"payload");
         assert!(leftovers(dir.path(), "planned-name.bin").is_empty());
     }
@@ -362,7 +393,8 @@ mod tests {
         let dir = temp();
         let dest = dir.path().join("a.bin");
 
-        download(&server.url("/from"), &dest, 0o755, None).expect("redirects must be followed");
+        download(&server.url("/from"), &dest, 0o755, None, "fixture")
+            .expect("redirects must be followed");
         assert_eq!(std::fs::read(&dest).unwrap(), b"payload");
     }
 
@@ -373,7 +405,7 @@ mod tests {
         let dir = temp();
         let dest = dir.path().join("nothing-like-the-url");
 
-        download(&server.url("/some/deep/path/other-name"), &dest, 0o755, None).unwrap();
+        download(&server.url("/some/deep/path/other-name"), &dest, 0o755, None, "fixture").unwrap();
         assert!(dest.exists(), "the planned name must win");
     }
 
@@ -387,7 +419,7 @@ mod tests {
             let dir = temp();
             let dest = dir.path().join("pkg.masp");
 
-            download(&server.url("/x"), &dest, 0o644, None).unwrap();
+            download(&server.url("/x"), &dest, 0o644, None, "fixture").unwrap();
             assert_eq!(
                 std::fs::metadata(&dest).unwrap().permissions().mode() & 0o777,
                 0o644,
@@ -439,7 +471,7 @@ mod tests {
         let dir = temp();
         let dest = dir.path().join("miden-vm");
 
-        download(&server.url("/vm.tar.gz"), &dest, 0o755, Some(SupportedFormat::TarGz))
+        download(&server.url("/vm.tar.gz"), &dest, 0o755, Some(SupportedFormat::TarGz), "fixture")
             .expect("should succeed");
 
         assert_eq!(std::fs::read(&dest).unwrap(), b"binary");
@@ -476,8 +508,14 @@ mod tests {
         let dir = temp();
         let dest = dir.path().join("miden-vm");
 
-        let err = download(&server.url("/vm.tar.gz"), &dest, 0o755, Some(SupportedFormat::TarGz))
-            .expect_err("must fail");
+        let err = download(
+            &server.url("/vm.tar.gz"),
+            &dest,
+            0o755,
+            Some(SupportedFormat::TarGz),
+            "fixture",
+        )
+        .expect_err("must fail");
         assert!(matches!(err, ExecError::Archive(_)), "{err}");
         assert!(!dest.exists(), "the container must never be installed as the artifact");
         assert!(leftovers(dir.path(), "miden-vm").is_empty(), "no partial files");

--- a/src/install/download.rs
+++ b/src/install/download.rs
@@ -133,8 +133,6 @@ fn fetch(uri: &str, label: &str) -> Result<Vec<u8>, ExecError> {
         reason: err.description().to_string(),
     })?;
 
-    crate::trace!("GET {uri}");
-
     // Shared with the progress callback below, which runs while `write_function` also holds a
     // borrow of `body`. Dropped at the end of this scope, which erases the display whether the
     // transfer succeeded or failed.
@@ -162,6 +160,7 @@ fn fetch(uri: &str, label: &str) -> Result<Vec<u8>, ExecError> {
                 uri: uri.to_string(),
                 reason: err.description().to_string(),
             })?;
+        crate::trace!("GET {uri}");
         transfer.perform().map_err(|err| ExecError::Transfer {
             uri: uri.to_string(),
             reason: err.description().to_string(),

--- a/src/install/extract.rs
+++ b/src/install/extract.rs
@@ -11,7 +11,7 @@
 //! This kind is closed to new channels (see [crate::manifest::ComponentKind::LegacyPackage]). When
 //! the channels that use it are backfilled with prebuilt artifacts, this module goes with them.
 
-use std::{collections::BTreeMap, path::Path};
+use std::{collections::BTreeMap, ffi::OsString, path::Path};
 
 use crate::plan::{PlanStep, ResolvedAuthority};
 
@@ -50,7 +50,8 @@ pub fn render_script(steps: &[PlanStep]) -> Option<String> {
     }
 
     let mut script = String::new();
-    script.push_str("#!/usr/bin/env cargo\n---cargo\n[dependencies]\n");
+    script.push_str("#!/usr/bin/env cargo\n---cargo\n[package]\nedition = \"2024\"\n\n");
+    script.push_str("[dependencies]\n");
     for (name, spec) in &dependencies {
         script.push_str(&format!("{name} = {{ {spec} }}\n"));
     }
@@ -111,7 +112,7 @@ fn dependency_spec(authority: &ResolvedAuthority, features: &[String]) -> String
 }
 
 /// Writes and runs the extraction script, if the plan needs one.
-pub fn extract(steps: &[PlanStep], script_path: &Path) -> Result<(), ExtractError> {
+pub fn extract(steps: &[PlanStep], script_path: &Path, verbose: bool) -> Result<(), ExtractError> {
     let Some(script) = render_script(steps) else {
         return Ok(());
     };
@@ -119,12 +120,21 @@ pub fn extract(steps: &[PlanStep], script_path: &Path) -> Result<(), ExtractErro
     std::fs::write(script_path, script)
         .map_err(|source| ExtractError::Write { path: script_path.to_path_buf(), source })?;
 
-    let status = std::process::Command::new("cargo")
-        .args(["+nightly", "-Zscript"])
-        .arg(script_path)
+    let argv = argv_for(script_path, verbose);
+    crate::trace!(
+        "running: cargo {}",
+        argv.iter().map(|a| a.to_string_lossy()).collect::<Vec<_>>().join(" ")
+    );
+
+    let mut command = std::process::Command::new("cargo");
+    command
+        .args(&argv)
         .stderr(std::process::Stdio::inherit())
-        .stdout(std::process::Stdio::inherit())
-        .status()
+        .stdout(std::process::Stdio::inherit());
+
+    // One script covers every package in the plan, so the wait belongs to all of them rather than
+    // to a component that could be named here.
+    let status = crate::install::run_reporting_progress(&mut command, "extracting packages")
         .map_err(|err| ExtractError::Spawn(err.to_string()))?;
 
     if !status.success() {
@@ -133,11 +143,39 @@ pub fn extract(steps: &[PlanStep], script_path: &Path) -> Result<(), ExtractErro
     Ok(())
 }
 
+/// The exact argument vector for the extraction run.
+///
+/// Split out so the shape of the command can be asserted without running a compiler.
+fn argv_for(script_path: &Path, verbose: bool) -> Vec<OsString> {
+    let mut argv: Vec<OsString> = vec!["+nightly".into(), "-Zscript".into()];
+    if !verbose {
+        argv.push("--quiet".into());
+    }
+    argv.push(script_path.into());
+    argv
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
 
     use super::*;
+
+    #[test]
+    fn the_extraction_script_is_quiet_below_verbose() {
+        let quiet = argv_for(Path::new("/s/extract.rs"), false);
+        assert!(quiet.iter().any(|a| a == "--quiet"), "{quiet:?}");
+
+        let loud = argv_for(Path::new("/s/extract.rs"), true);
+        assert!(!loud.iter().any(|a| a == "--quiet"), "{loud:?}");
+
+        // The script path stays last either way: cargo reads it as the program to run, not as a
+        // value for whatever flag precedes it.
+        for argv in [quiet, loud] {
+            assert_eq!(argv.last().unwrap(), "/s/extract.rs");
+            assert_eq!(argv.first().unwrap(), "+nightly");
+        }
+    }
 
     fn extraction(crate_name: &str, dest: &str, extractor: &str) -> PlanStep {
         PlanStep::ExtractPackage {
@@ -296,7 +334,7 @@ impl Lib {
         };
 
         let script_path = temp.path().join("extract.rs");
-        extract(&[step], &script_path).expect("the generated script must compile and run");
+        extract(&[step], &script_path, true).expect("the generated script must compile and run");
 
         assert_eq!(
             std::fs::read(&dest).unwrap(),

--- a/src/install/mod.rs
+++ b/src/install/mod.rs
@@ -9,6 +9,31 @@ pub mod download;
 pub mod extract;
 pub mod stage;
 
+use std::{
+    process::{Command, ExitStatus},
+    time::Duration,
+};
+
+/// How often a running child is checked on, and its elapsed display redrawn.
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Runs `command` to completion, showing a live elapsed line for `label` while it works.
+///
+/// Polled rather than driven by a ticker thread: the erase-before-write bookkeeping is
+/// thread-local, and the executor is sequential.
+pub fn run_reporting_progress(command: &mut Command, label: &str) -> std::io::Result<ExitStatus> {
+    let mut activity = crate::report::Activity::begin(label);
+    let mut child = command.spawn()?;
+
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(status);
+        }
+        activity.tick();
+        std::thread::sleep(POLL_INTERVAL);
+    }
+}
+
 pub use self::{
     archive::ArchiveError,
     cargo::{CargoError, argv_for, build as cargo_build},

--- a/src/install/stage.rs
+++ b/src/install/stage.rs
@@ -1,7 +1,7 @@
 //! Building a staged installation tree and checking it before it is published.
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     path::{Path, PathBuf},
 };
 
@@ -144,9 +144,18 @@ pub fn execute(
 ) -> Result<Realized, StageError> {
     let mut pending_extractions = Vec::new();
     let mut realized = Realized::new();
+    let mut announced = BTreeSet::new();
+
+    let planned = planned_announcements(plan);
+    announce_summary(&planned);
+    let mut progress = Progress { done: 0, total: planned.len() };
 
     for step in &plan.steps {
         if step.dest().exists() {
+            crate::trace!(
+                "carried forward from the previous publication: {}",
+                step.dest().display()
+            );
             continue;
         }
 
@@ -155,6 +164,8 @@ pub fn execute(
             pending_extractions.push(step.clone());
             continue;
         }
+
+        announce(step, &mut announced, Some(&mut progress));
 
         let method = match run(step, staging_root, verbose, debug) {
             Ok(method) => method,
@@ -165,12 +176,8 @@ pub fn execute(
                 let Some(fallback) = step.fallback() else {
                     return Err(err);
                 };
-                println!(
-                    "{}: could not acquire {}: {err}",
-                    "warning".yellow().bold(),
-                    step.owner().white().bold(),
-                );
-                println!("building {} from source instead", step.owner().white().bold());
+                crate::warn!("could not acquire {}: {err}", step.owner().bold());
+                announce(fallback, &mut announced, None);
                 run(fallback, staging_root, verbose, debug)?
             },
         };
@@ -179,8 +186,11 @@ pub fn execute(
     }
 
     if !pending_extractions.is_empty() {
+        for step in &pending_extractions {
+            announce(step, &mut announced, Some(&mut progress));
+        }
         let script = staging_root.join("extract").with_extension("rs");
-        crate::install::extract(&pending_extractions, &script)?;
+        crate::install::extract(&pending_extractions, &script, verbose)?;
         // The script is a build artefact, not part of the toolchain.
         let _ = std::fs::remove_file(&script);
         for step in &pending_extractions {
@@ -191,6 +201,106 @@ pub fn execute(
     create_symlinks(plan, staging_root)?;
 
     Ok(realized)
+}
+
+/// The kind of work a step performs, as the announcements name it.
+fn action_of(step: &PlanStep) -> &'static str {
+    match step {
+        PlanStep::Download { .. } => "downloading",
+        PlanStep::CopyLocal { .. } => "copying",
+        PlanStep::CargoBuild { .. } => "building",
+        PlanStep::ExtractPackage { .. } => "extracting",
+    }
+}
+
+/// How far through the announcements the install is. A position in a list, not an estimate of
+/// time remaining: the steps are wildly unequal.
+struct Progress {
+    done: usize,
+    total: usize,
+}
+
+/// Every announcement this plan will make, deduplicated and filtered exactly as [announce] is, so
+/// the counter always reaches its total.
+fn planned_announcements(plan: &InstallationPlan) -> Vec<(String, &'static str)> {
+    let mut seen = BTreeSet::new();
+    let mut planned = Vec::new();
+
+    for step in &plan.steps {
+        if step.dest().exists() {
+            continue;
+        }
+        let entry = (step.owner().to_string(), action_of(step));
+        if seen.insert(entry.clone()) {
+            planned.push(entry);
+        }
+    }
+
+    planned
+}
+
+/// States what kind of work is ahead before any of it starts, chiefly so a multi-minute source
+/// build is known about before the pause it causes.
+fn announce_summary(planned: &[(String, &'static str)]) {
+    if planned.is_empty() {
+        return;
+    }
+
+    // A fixed order, so the same plan reads the same way every time.
+    let described: Vec<String> = ["downloading", "copying", "building", "extracting"]
+        .into_iter()
+        .filter_map(|action| {
+            let count = planned.iter().filter(|(_, kind)| *kind == action).count();
+            if count == 0 {
+                return None;
+            }
+            let (singular, plural) = match action {
+                "downloading" => ("download", "downloads"),
+                "copying" => ("copy", "copies"),
+                "building" => ("source build", "source builds"),
+                _ => ("extraction", "extractions"),
+            };
+            Some(format!("{count} {}", if count == 1 { singular } else { plural }))
+        })
+        .collect();
+
+    crate::info!("{} steps: {}", planned.len(), described.join(", "));
+}
+
+/// Announces the work a step is about to do, once per component and kind of work.
+///
+/// `progress` is absent for an unplanned step (a taken fallback), which is left un-numbered rather
+/// than pushed past a total fixed before the run began.
+fn announce(
+    step: &PlanStep,
+    announced: &mut BTreeSet<(String, &'static str)>,
+    progress: Option<&mut Progress>,
+) {
+    let action = action_of(step);
+    if !announced.insert((step.owner().to_string(), action)) {
+        return;
+    }
+
+    // Where a source build is the one thing a user is most likely to want to know about, because
+    // it is the one that takes minutes rather than seconds.
+    let source = if matches!(step, PlanStep::CargoBuild { .. }) {
+        " from source"
+    } else {
+        ""
+    };
+
+    match progress {
+        Some(progress) => {
+            progress.done += 1;
+            crate::info!(
+                "[{}/{}] {action} component '{}'{source}",
+                progress.done,
+                progress.total,
+                step.owner().bold()
+            );
+        },
+        None => crate::info!("{action} component '{}'{source}", step.owner().bold()),
+    }
 }
 
 /// Performs one step, reporting how its output was produced.
@@ -228,6 +338,7 @@ fn create_symlinks(plan: &InstallationPlan, staging_root: &Path) -> Result<(), S
         // Relative, so the shim keeps working when the publication directory is renamed or
         // reached through a different path.
         let target = Path::new("..").join("bin").join(&symlink.target_binary);
+        crate::trace!("linking {} -> {}", link.display(), target.display());
         utils::fs::symlink(&link, &target).map_err(|err| StageError::Create {
             path: link,
             source: std::io::Error::other(err.to_string()),

--- a/src/install/stage.rs
+++ b/src/install/stage.rs
@@ -116,6 +116,7 @@ pub fn seed(plan: &InstallationPlan, into: &Path, from: &Seed<'_>) -> Result<(),
             std::fs::create_dir_all(parent)
                 .map_err(|source| StageError::Seed { path: dest.clone(), source })?;
         }
+        crate::trace!("seeding {} from the previous publication", dest.display());
         std::fs::copy(&src, &dest)
             .map_err(|source| StageError::Seed { path: dest.clone(), source })?;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod paths;
 pub mod plan;
 pub mod profile;
 pub mod publish;
+pub mod report;
 pub mod resolve;
 pub mod state;
 mod toolchain;

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -15,7 +15,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use colored::Colorize;
 use fs4::FileExt;
 
 /// How long to wait before telling the user why nothing is happening.
@@ -101,10 +100,7 @@ pub fn acquire(home: &Path) -> Result<HomeLock, LockError> {
         }
 
         if !notified && start.elapsed() >= NOTIFY_AFTER {
-            println!(
-                "{}: waiting for another midenup operation to finish...",
-                "info".white().bold()
-            );
+            crate::info!("waiting for another midenup operation to finish...");
             notified = true;
         }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -145,6 +145,7 @@ impl VersionedManifest {
         let uri = uri.as_ref();
 
         if let Some(manifest_path) = uri.strip_prefix("file://") {
+            crate::trace!("reading {manifest_path}");
             let contents = std::fs::read_to_string(manifest_path)
                 .map_err(|_| ManifestError::Missing(manifest_path.to_string()))?;
             if contents.is_empty() {
@@ -174,6 +175,7 @@ impl VersionedManifest {
                     Ok(new_data.len())
                 })
                 .map_err(curl_error)?;
+            crate::trace!("GET {uri}");
             transfer.perform().map_err(curl_error)?;
         }
 

--- a/src/miden_wrapper.rs
+++ b/src/miden_wrapper.rs
@@ -166,10 +166,7 @@ impl<'a> ToolchainEnvironment<'a> {
                 .get_aliases()
                 .map_err(|err| EnvironmentError::AmbiguousAlias { reason: err.to_string() })?;
         } else if let Err(err) = self.installed_channel.get_aliases() {
-            eprintln!(
-                "{}: {err}. Naming the component directly resolves it unambiguously.",
-                "warning".yellow().bold()
-            );
+            crate::warn!("{err}. Naming the component directly resolves it unambiguously.");
         }
 
         // Local function that tries to parse an argument given a channel's state.
@@ -194,9 +191,8 @@ impl<'a> ToolchainEnvironment<'a> {
 
             let warning_message = match (&miden_argument, not_found_in_active) {
                 (MidenArgument::Alias { component, .. }, true) => Some(format!(
-                    "{}: '{argument}' is an alias from component {}, which is installed but is \
-                     not part of the current active toolchain.",
-                    "WARNING".yellow().bold(),
+                    "'{argument}' is an alias from component {}, which is installed but is not \
+                     part of the current active toolchain.",
                     component.name,
                 )),
                 (
@@ -205,14 +201,13 @@ impl<'a> ToolchainEnvironment<'a> {
                     | MidenArgument::Component { component, .. },
                     true,
                 ) => Some(format!(
-                    "{}: '{}' is installed, but it is not part of the current active toolchain.",
-                    "WARNING".yellow().bold(),
+                    "'{}' is installed, but it is not part of the current active toolchain.",
                     component.name,
                 )),
                 _ => None,
             };
             if let Some(warning) = warning_message {
-                println!("{warning}")
+                crate::warn!("{warning}")
             };
 
             Ok(ExecutionEnvironment {
@@ -543,9 +538,7 @@ pub fn display_version(config: &Config) -> String {
                 })
             })
             .inspect_err(|e| {
-                println!("Failed to obtain cargo version:");
-                println!("{}", e);
-                println!("Leaving as unknown")
+                crate::warn!("failed to obtain the cargo version ({e}); leaving it as unknown")
             })
             .unwrap_or("unknown".to_string())
     };
@@ -560,9 +553,7 @@ pub fn display_version(config: &Config) -> String {
                 .ok_or(anyhow!("channel: {} doesn't exist or isn't available ", toolchain.channel))
         })
         .inspect_err(|err| {
-            println!(
-                "failed to obtain current toolchain error because of: {err}, leaving as unknown"
-            )
+            crate::warn!("failed to obtain the current toolchain ({err}); leaving it as unknown")
         })
         .unwrap_or("unknown".to_string());
 

--- a/src/migrate_networks.rs
+++ b/src/migrate_networks.rs
@@ -148,7 +148,7 @@ fn adopt_var_for_default_network(home: &Path, legacy: &Path) -> anyhow::Result<b
 
     match std::fs::rename(&source, &destination) {
         Ok(()) => {
-            println!(
+            crate::info!(
                 "moved your {DEFAULT_NETWORK} data from {} to {}: it is now keyed by the network \
                  rather than by the toolchain version.\nIf a project of yours pins {} in \
                  miden-toolchain.toml, move it back with:  mv {} {}",

--- a/src/options.rs
+++ b/src/options.rs
@@ -26,9 +26,6 @@ pub struct InstallationOptions {
     /// The toolchain profile to install
     #[arg(long, short, default_value = "minimal")]
     pub profile: Profile,
-    /// Displays the entirety of cargo's output when performing installations.
-    #[arg(long, short, default_value = "false")]
-    pub verbose: bool,
     /// Components to install in addition to the profile's members
     #[arg(long = "component", value_name = "COMPONENT")]
     pub components: Vec<String>,
@@ -59,9 +56,6 @@ pub struct InstallationOptions {
 /// Optional update settings.
 #[derive(Default, Debug, Parser, Clone, Copy)]
 pub struct UpdateOptions {
-    /// Displays the entirety of cargo's output when performing installations.
-    #[clap(long, short, default_value = "false")]
-    pub verbose: bool,
     /// Determines how midenup will handle updates for components installed from a path
     #[clap(value_enum, short, long, default_value = "off")]
     pub path_update: PathUpdate,
@@ -82,19 +76,15 @@ pub enum PathUpdate {
 }
 
 impl From<InstallationOptions> for UpdateOptions {
-    fn from(value: InstallationOptions) -> Self {
-        UpdateOptions {
-            verbose: value.verbose,
-            ..Default::default()
-        }
+    fn from(_value: InstallationOptions) -> Self {
+        UpdateOptions::default()
     }
 }
 
 impl From<UpdateOptions> for InstallationOptions {
-    fn from(value: UpdateOptions) -> Self {
+    fn from(_value: UpdateOptions) -> Self {
         InstallationOptions {
             profile: Profile::Minimal,
-            verbose: value.verbose,
             components: Vec::new(),
             stale: Vec::new(),
             held_back: Vec::new(),

--- a/src/publish/journal.rs
+++ b/src/publish/journal.rs
@@ -160,6 +160,7 @@ pub fn commit_symlink(home: &Path, entry: &JournalEntry) -> Result<(), PublishEr
         },
     };
 
+    crate::trace!("committing {} to {}", link.display(), target.display());
     utils::fs::replace_symlink(&link, &target).map_err(|err| PublishError::Commit {
         path: link,
         source: std::io::Error::other(err.to_string()),
@@ -209,7 +210,9 @@ pub fn clean(home: &Path, entry: &JournalEntry) -> Result<(), PublishError> {
     if let Some(old) = &entry.old_publication
         && matches!(entry.kind, OperationKind::Uninstall)
     {
-        let _ = std::fs::remove_dir_all(paths::publication_dir(home, &entry.channel, old));
+        let publication = paths::publication_dir(home, &entry.channel, old);
+        crate::trace!("removing {}", publication.display());
+        let _ = std::fs::remove_dir_all(publication);
     }
 
     if matches!(entry.kind, OperationKind::Uninstall) {
@@ -261,16 +264,29 @@ pub fn recover(home: &Path, state: &mut LocalState) -> Result<Option<OperationKi
     };
 
     if committed {
+        crate::trace!(
+            "the interrupted {} of {} was committed; completing it",
+            entry.kind,
+            entry.channel
+        );
         finish(home, &entry, state)?;
         return Ok(Some(entry.kind));
     }
 
     // Not committed: the operation never happened. Discard the staged publication and leave prior
     // state exactly as it was.
+    crate::trace!(
+        "the interrupted {} of {} never committed; discarding it",
+        entry.kind,
+        entry.channel
+    );
     if let Some(new) = &entry.new_publication {
-        let _ = std::fs::remove_dir_all(paths::publication_dir(home, &entry.channel, new));
+        let publication = paths::publication_dir(home, &entry.channel, new);
+        crate::trace!("removing {}", publication.display());
+        let _ = std::fs::remove_dir_all(publication);
     }
     let path = entry_path(home, &entry.id);
+    crate::trace!("removing {}", path.display());
     std::fs::remove_file(&path).map_err(|source| PublishError::Journal { path, source })?;
 
     Ok(Some(entry.kind))

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,0 +1,365 @@
+//! What `midenup` says while it works, and how much of it (spec section 14.4).
+//!
+//! Everything here goes to stderr; stdout carries results only. Verbose and above also display
+//! cargo's output; debug additionally traces midenup's own actions. The level comes from the
+//! `-q`/`-v` flags.
+//!
+//! Note that an install triggered by `miden` command always runs at the default level.
+
+use std::{
+    cell::RefCell,
+    fmt,
+    io::{IsTerminal, Write},
+    sync::atomic::{AtomicU8, Ordering},
+    time::{Duration, Instant},
+};
+
+use colored::Colorize;
+
+/// How much `midenup` says about what it is doing.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Verbosity {
+    /// Warnings and errors only. No progress, no announcements.
+    Quiet,
+    /// One line per component as it is acquired, plus a live transfer display on a terminal.
+    #[default]
+    Normal,
+    /// The above, and the output of spawned programs (e.g. cargo) is no longer suppressed.
+    Verbose,
+    /// The above, and every action `midenup` takes is traced.
+    Debug,
+}
+
+impl Verbosity {
+    /// Resolves the level in effect from the `-q`/`-v` flags.
+    pub fn resolve(quiet: bool, verbose: u8) -> Self {
+        if quiet {
+            return Self::Quiet;
+        }
+        match verbose {
+            0 => Self::Normal,
+            1 => Self::Verbose,
+            _ => Self::Debug,
+        }
+    }
+}
+
+/// The level in effect, as a [Verbosity] discriminant.
+///
+/// Process-global because the things that report are not all reachable from a [crate::config]:
+/// [crate::lock] is handed a path, and the executors are handed a plan.
+static LEVEL: AtomicU8 = AtomicU8::new(Verbosity::Normal as u8);
+
+/// Installs the level for the rest of the process. Called once, from [crate::commands::Midenup].
+pub fn set(verbosity: Verbosity) {
+    LEVEL.store(verbosity as u8, Ordering::Relaxed);
+}
+
+/// The level in effect.
+pub fn verbosity() -> Verbosity {
+    match LEVEL.load(Ordering::Relaxed) {
+        0 => Verbosity::Quiet,
+        1 => Verbosity::Normal,
+        2 => Verbosity::Verbose,
+        _ => Verbosity::Debug,
+    }
+}
+
+/// Whether the output of spawned programs is shown rather than suppressed.
+pub fn subprocess_output_visible() -> bool {
+    verbosity() >= Verbosity::Verbose
+}
+
+/// Whether a live, redrawn transfer display is appropriate.
+pub fn transfers_are_live() -> bool {
+    // skip if this is not a terminal, we don't need transfer data for file/CI logs.
+    verbosity() >= Verbosity::Normal && std::io::stderr().is_terminal()
+}
+
+/// Whether a live, redrawn line for a long-running child process is appropriate.
+///
+/// Only at exactly [Verbosity::Normal]: above it the child's own output is shown, and a line
+/// redrawn underneath would interleave with it.
+pub fn activity_is_live() -> bool {
+    verbosity() == Verbosity::Normal && std::io::stderr().is_terminal()
+}
+
+/// Emits a labelled line at [Verbosity::Normal] and above. Prefer the [crate::info] macro.
+pub fn emit_info(args: fmt::Arguments) {
+    if verbosity() >= Verbosity::Normal {
+        write_line(format_args!("{}: {args}", "info".bold()));
+    }
+}
+
+/// Emits an unlabelled line at [Verbosity::Normal] and above. Prefer the [crate::note] macro.
+pub fn emit_note(args: fmt::Arguments) {
+    if verbosity() >= Verbosity::Normal {
+        write_line(args);
+    }
+}
+
+/// Emits a labelled line at every level. Prefer the [crate::warn] macro.
+pub fn emit_warning(args: fmt::Arguments) {
+    write_line(format_args!("{}: {args}", "warning".yellow().bold()));
+}
+
+/// Emits at [Verbosity::Debug] only, labelled. Prefer the [crate::trace] macro.
+pub fn emit_trace(args: fmt::Arguments) {
+    if verbosity() >= Verbosity::Debug {
+        let mut stderr = std::io::stderr().lock();
+        let _ = writeln!(stderr, "{}: {args}", "debug".magenta().bold());
+    }
+}
+
+/// Writes one line to stderr, erasing a live transfer display first so the two never collide.
+fn write_line(args: fmt::Arguments) {
+    let mut stderr = std::io::stderr().lock();
+    Transfer::erase(&mut stderr);
+    let _ = writeln!(stderr, "{args}");
+}
+
+/// An `info:` line, at [Verbosity::Normal] and above.
+///
+/// The label belongs to the level, not to the call site: spelling it per-message is how a codebase
+/// ends up emitting `info`, `warning`, `WARNING` and `warn` for two levels.
+#[macro_export]
+macro_rules! info {
+    ($($arg:tt)*) => { $crate::report::emit_info(format_args!($($arg)*)) };
+}
+
+/// An unlabelled line at the same level as [crate::info].
+///
+/// For continuation lines under a labelled one -- the members of a list the `info:` line above
+/// introduced -- where a second label would be noise.
+#[macro_export]
+macro_rules! note {
+    ($($arg:tt)*) => { $crate::report::emit_note(format_args!($($arg)*)) };
+}
+
+/// A `warning:` line, at every level including [Verbosity::Quiet].
+#[macro_export]
+macro_rules! warn {
+    ($($arg:tt)*) => { $crate::report::emit_warning(format_args!($($arg)*)) };
+}
+
+/// An action trace, at [Verbosity::Debug] only.
+#[macro_export]
+macro_rules! trace {
+    ($($arg:tt)*) => { $crate::report::emit_trace(format_args!($($arg)*)) };
+}
+
+/// How often the transfer display is redrawn.
+///
+/// Redrawing per callback would spend more time formatting than transferring; curl calls the
+/// progress function on every internal read.
+const REDRAW_INTERVAL: Duration = Duration::from_millis(100);
+
+// Whether a transient line is currently on screen, and so must be erased before anything else is
+// written to stderr.
+//
+// Thread-local rather than global: a transfer is drawn by the thread performing it, and the
+// executor is sequential. A future concurrent executor cannot share one line anyway.
+thread_local! {
+    static LINE_PENDING: RefCell<bool> = const { RefCell::new(false) };
+}
+
+/// A live, single-line display of one artifact transfer.
+///
+/// Transient by design: it is erased when the transfer ends, leaving only the announcement line
+/// for that component. Progress is about *waiting*; once the wait is over it is not a result worth
+/// keeping in the scrollback.
+pub struct Transfer {
+    label: String,
+    started: Instant,
+    last_drawn: Option<Instant>,
+    live: bool,
+}
+
+impl Transfer {
+    /// Begins reporting a transfer of `label`, which is a component name.
+    pub fn begin(label: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            started: Instant::now(),
+            last_drawn: None,
+            live: transfers_are_live(),
+        }
+    }
+
+    /// Reports that `done` of `total` bytes have arrived. A `total` of zero means the response did
+    /// not say, so only what has arrived is shown.
+    pub fn update(&mut self, done: u64, total: u64) {
+        if !self.live || done == 0 {
+            return;
+        }
+        let now = Instant::now();
+        if self.last_drawn.is_some_and(|last| now.duration_since(last) < REDRAW_INTERVAL) {
+            return;
+        }
+        self.last_drawn = Some(now);
+
+        let elapsed = now.duration_since(self.started).as_secs_f64();
+        let rate = if elapsed > 0.0 { done as f64 / elapsed } else { 0.0 };
+        let transferred = if total > 0 {
+            format!("{}/{}", bytes(done), bytes(total))
+        } else {
+            bytes(done)
+        };
+
+        let mut stderr = std::io::stderr().lock();
+        let _ =
+            write!(stderr, "\r\x1b[2K  {}  {transferred} ({}/s)", self.label, bytes(rate as u64));
+        let _ = stderr.flush();
+        LINE_PENDING.with_borrow_mut(|pending| *pending = true);
+    }
+
+    /// Clears a pending transient line so that a permanent one can be written over it.
+    fn erase(stderr: &mut impl Write) {
+        LINE_PENDING.with_borrow_mut(|pending| {
+            if *pending {
+                let _ = write!(stderr, "\r\x1b[2K");
+                let _ = stderr.flush();
+                *pending = false;
+            }
+        });
+    }
+}
+
+impl Drop for Transfer {
+    /// Erases the display when the transfer ends, however it ends. A failed transfer leaves an
+    /// error on stderr, and the half-drawn line it was on must not be part of it.
+    fn drop(&mut self) {
+        if self.live {
+            let mut stderr = std::io::stderr().lock();
+            Self::erase(&mut stderr);
+        }
+    }
+}
+
+/// A live, single-line elapsed display for one long-running child process, e.g. a source build.
+///
+/// Shows only that time is passing -- deliberately not parsed out of cargo's output, which is a
+/// human-facing rendering rather than an interface. Transient like [Transfer].
+pub struct Activity {
+    label: String,
+    started: Instant,
+    last_drawn: Option<Instant>,
+    live: bool,
+}
+
+impl Activity {
+    /// Begins reporting work on `label`, which is a component name.
+    pub fn begin(label: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            started: Instant::now(),
+            last_drawn: None,
+            live: activity_is_live(),
+        }
+    }
+
+    /// Redraws the elapsed time, at most once per [REDRAW_INTERVAL].
+    pub fn tick(&mut self) {
+        if !self.live {
+            return;
+        }
+        let now = Instant::now();
+        if self.last_drawn.is_some_and(|last| now.duration_since(last) < REDRAW_INTERVAL) {
+            return;
+        }
+        self.last_drawn = Some(now);
+
+        let mut stderr = std::io::stderr().lock();
+        let _ = write!(
+            stderr,
+            "\r\x1b[2K  {}  {}",
+            self.label,
+            elapsed(now.duration_since(self.started))
+        );
+        let _ = stderr.flush();
+        LINE_PENDING.with_borrow_mut(|pending| *pending = true);
+    }
+}
+
+impl Drop for Activity {
+    /// As [Transfer::drop]: erased however the wait ends, so an error never shares its line.
+    fn drop(&mut self) {
+        if self.live {
+            let mut stderr = std::io::stderr().lock();
+            Transfer::erase(&mut stderr);
+        }
+    }
+}
+
+/// Formats a wait as whole seconds, and minutes once there are any.
+fn elapsed(duration: Duration) -> String {
+    let seconds = duration.as_secs();
+    if seconds >= 60 {
+        format!("{}m{:02}s", seconds / 60, seconds % 60)
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+/// Formats a byte count the way a transfer is usually read: two significant decimals, binary
+/// units.
+fn bytes(count: u64) -> String {
+    const UNITS: [&str; 4] = ["B", "KiB", "MiB", "GiB"];
+    let mut value = count as f64;
+    let mut unit = 0;
+    while value >= 1024.0 && unit < UNITS.len() - 1 {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{count} {}", UNITS[0])
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_wait_is_formatted_in_minutes_once_there_are_any() {
+        assert_eq!(elapsed(Duration::from_secs(0)), "0s");
+        assert_eq!(elapsed(Duration::from_secs(59)), "59s");
+        assert_eq!(elapsed(Duration::from_secs(60)), "1m00s");
+        assert_eq!(elapsed(Duration::from_secs(72)), "1m12s");
+        assert_eq!(elapsed(Duration::from_secs(3599)), "59m59s");
+
+        // Truncated, so the count stays monotonic.
+        assert_eq!(elapsed(Duration::from_millis(1900)), "1s");
+    }
+
+    #[test]
+    fn flags_ladder_upwards_and_saturate() {
+        assert_eq!(Verbosity::resolve(false, 0), Verbosity::Normal);
+        assert_eq!(Verbosity::resolve(false, 1), Verbosity::Verbose);
+        assert_eq!(Verbosity::resolve(false, 2), Verbosity::Debug);
+        assert_eq!(Verbosity::resolve(false, 9), Verbosity::Debug);
+    }
+
+    #[test]
+    fn only_verbose_and_above_reveal_subprocess_output() {
+        for (level, visible) in [
+            (Verbosity::Quiet, false),
+            (Verbosity::Normal, false),
+            (Verbosity::Verbose, true),
+            (Verbosity::Debug, true),
+        ] {
+            set(level);
+            assert_eq!(subprocess_output_visible(), visible, "at {level:?}");
+        }
+        set(Verbosity::Normal);
+    }
+
+    #[test]
+    fn byte_counts_read_as_transfers() {
+        assert_eq!(bytes(512), "512 B");
+        assert_eq!(bytes(1536), "1.5 KiB");
+        assert_eq!(bytes(10 * 1024 * 1024), "10.0 MiB");
+    }
+}

--- a/src/report.rs
+++ b/src/report.rs
@@ -107,8 +107,7 @@ pub fn emit_warning(args: fmt::Arguments) {
 /// Emits at [Verbosity::Debug] only, labelled. Prefer the [crate::trace] macro.
 pub fn emit_trace(args: fmt::Arguments) {
     if verbosity() >= Verbosity::Debug {
-        let mut stderr = std::io::stderr().lock();
-        let _ = writeln!(stderr, "{}: {args}", "debug".magenta().bold());
+        write_line(format_args!("{}: {args}", "debug".magenta().bold()));
     }
 }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -71,6 +71,7 @@ pub fn subprocess_output_visible() -> bool {
 }
 
 /// Whether a live, redrawn transfer display is appropriate.
+/// level check. Without it the announcement lines remain, which is the whole report in that case.
 pub fn transfers_are_live() -> bool {
     // skip if this is not a terminal, we don't need transfer data for file/CI logs.
     verbosity() >= Verbosity::Normal && std::io::stderr().is_terminal()

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -126,6 +126,7 @@ impl LocalState {
 
     /// Writes state to `path`, refusing to commit anything that cannot be read back.
     pub fn save(&self, path: &Path) -> Result<(), StateError> {
+        crate::trace!("writing {}", path.display());
         crate::utils::atomic::write_validated(path, self, |written| {
             LocalState::parse_str(written, path)
                 .map(|_| ())

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -179,10 +179,7 @@ impl Toolchain {
         // The active view is resolved against the *installed* snapshot rather than upstream, which
         // is what section 8.5 says it is -- this project's request, against what this machine has.
         if let Some(view) = active_view(config, state, desired_channel, &intent) {
-            println!(
-                "{}: current toolchain is {desired_channel} and is installed",
-                "info".white().bold()
-            );
+            crate::info!("current toolchain is {desired_channel} and is installed");
             return Ok((current_toolchain, justification, Some(view)));
         }
 
@@ -223,23 +220,17 @@ impl Toolchain {
             Some(installed) => {
                 let installed_components: HashSet<&str> =
                     HashSet::from_iter(installed.components.iter().map(|comp| comp.name.as_ref()));
-                println!(
-                    "{}: installing missing components of the current toolchain:",
-                    "info".white().bold()
-                );
+                crate::info!("installing missing components of the current toolchain:");
                 for component in resolved
                     .iter()
                     .map(|component| component.name.as_ref())
                     .filter(|name| !installed_components.contains(name))
                 {
-                    println!("- {}", component.white().bold());
+                    crate::note!("- {}", component.bold());
                 }
             },
             None => {
-                println!(
-                    "{}: current toolchain is {desired_channel}, but not yet installed",
-                    "info".white().bold()
-                );
+                crate::info!("current toolchain is {desired_channel}, but not yet installed");
             },
         }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -232,7 +232,7 @@ pub mod fs {
                     };
                 }
             } else {
-                println!("Failed to open {}, skipping it.", dir.display());
+                crate::warn!("Failed to open {}, skipping it.", dir.display());
             }
 
             (local_latest, current_entry_count)

--- a/tests/common/harness.rs
+++ b/tests/common/harness.rs
@@ -221,6 +221,31 @@ exit 0
 
         self
     }
+
+    /// Adds a component that is `cargo install`ed from a dependency-free local crate, so the real
+    /// build path runs in about a second. Opt-in: only this needs a working `cargo`.
+    pub fn with_cargo_component(mut self, name: &str) -> Self {
+        let package = format!("fixture-{name}");
+        let binary = format!("miden-{name}");
+
+        let source = self.dir.join(format!("{name}-source"));
+        write_trivial_crate(&source, &package, &binary);
+
+        let channel = self.channels.last_mut().expect("a channel must be added before a component");
+        channel["components"].as_array_mut().expect("components is an array").push(
+            serde_json::json!({
+                "name": name,
+                "version": {"kind": "path", "path": source.to_str().expect("utf-8 fixture path")},
+                "kind": "executable",
+                // No artifacts: the plan rejects them on a cargo-installed component.
+                "installation_method": {"kind": "cargo", "crate_name": package},
+                "installed-executable": binary,
+                "profiles": ["minimal"]
+            }),
+        );
+
+        self
+    }
 }
 
 /// Local `path`- and `git`-sourced crates, for exercising those authorities cheaply.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -23,18 +23,44 @@ macro_rules! full_path {
 
 pub type LocalManifest = midenup::state::LocalState;
 
+/// A command for the real binary with every variable it reads set or removed, so nothing is
+/// inherited from the developer's environment (e.g. their `MIDENUP_HOME`).
+pub fn midenup_command(
+    program: impl AsRef<std::ffi::OsStr>,
+    env: &TestEnvironment,
+    manifest_uri: &str,
+) -> std::process::Command {
+    let mut command = std::process::Command::new(program);
+    command
+        .current_dir(&env.present_working_dir)
+        .env("MIDENUP_HOME", &env.midenup_home)
+        .env("CARGO_HOME", &env.cargo_home)
+        .env("MIDENUP_MANIFEST_URI", manifest_uri)
+        .env_remove("XDG_DATA_HOME");
+    command
+}
+
+/// As [midenup_command], but the home is resolved from `XDG_DATA_HOME` the way a user's shell
+/// would, which is how the `miden` dispatch path locates it. `MIDENUP_HOME` would take precedence,
+/// so it is removed.
+pub fn midenup_command_via_xdg(
+    program: impl AsRef<std::ffi::OsStr>,
+    env: &TestEnvironment,
+    manifest_uri: &str,
+) -> std::process::Command {
+    let mut command = midenup_command(program, env, manifest_uri);
+    command.env_remove("MIDENUP_HOME").env("XDG_DATA_HOME", env.tmp_dir.path());
+    command
+}
+
 /// Runs the real `midenup` binary against a test environment.
 pub fn run_midenup(
     env: &TestEnvironment,
     manifest_uri: &str,
     args: &[&str],
 ) -> std::process::Output {
-    std::process::Command::new(env!("CARGO_BIN_EXE_midenup"))
+    midenup_command(env!("CARGO_BIN_EXE_midenup"), env, manifest_uri)
         .args(args)
-        .current_dir(&env.present_working_dir)
-        .env("MIDENUP_HOME", &env.midenup_home)
-        .env("CARGO_HOME", &env.cargo_home)
-        .env("MIDENUP_MANIFEST_URI", manifest_uri)
         .output()
         .expect("failed to run midenup")
 }

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -20,14 +20,11 @@ fn spawn_miden(
     env: &TestEnvironment,
     manifest_uri: &str,
 ) -> std::process::Child {
-    Command::new(miden)
+    // The `miden` path deliberately ignores `--midenup-home` and locates the home the way a
+    // user's shell would, which is what the `_via_xdg` variant arranges.
+    midenup_command_via_xdg(miden, env, manifest_uri)
         .args(["help", "vm"])
         .current_dir(project)
-        // The `miden` path deliberately ignores `--midenup-home` and locates the home the way a
-        // user's shell would.
-        .env("XDG_DATA_HOME", env.tmp_dir.path())
-        .env("CARGO_HOME", &env.cargo_home)
-        .env("MIDENUP_MANIFEST_URI", manifest_uri)
         // Piped so that a failure reports what the child said, including anything the component it
         // spawned wrote -- `execute_command` gives the component these same descriptors.
         .stdout(std::process::Stdio::piped())
@@ -141,12 +138,8 @@ fn integration_dispatch_against_an_installed_toolchain_makes_no_network_request(
     let fixture = common::harness::OfflineFixture::create(env.tmp_dir.path(), "0.15.0");
 
     // Install with a reachable manifest...
-    let install = Command::new(env!("CARGO_BIN_EXE_midenup"))
+    let install = midenup_command(env!("CARGO_BIN_EXE_midenup"), &env, &fixture.manifest_uri)
         .args(["install", "0.15.0"])
-        .current_dir(&env.present_working_dir)
-        .env("MIDENUP_HOME", &env.midenup_home)
-        .env("CARGO_HOME", &env.cargo_home)
-        .env("MIDENUP_MANIFEST_URI", &fixture.manifest_uri)
         .output()
         .expect("failed to run midenup");
     assert!(install.status.success(), "{}", String::from_utf8_lossy(&install.stderr));
@@ -169,13 +162,10 @@ fn integration_dispatch_against_an_installed_toolchain_makes_no_network_request(
     let project = env.tmp_dir.path().join("project");
     write_toolchain_file(&project, &[]);
 
-    let output = Command::new(&miden)
+    // Nothing listens on that port: reaching for upstream would fail, loudly.
+    let output = midenup_command_via_xdg(&miden, &env, "https://127.0.0.1:1/nope.json")
         .args(["help", "vm"])
         .current_dir(&project)
-        .env("XDG_DATA_HOME", env.tmp_dir.path())
-        .env("CARGO_HOME", &env.cargo_home)
-        // Nothing listens here: reaching for upstream would fail, loudly.
-        .env("MIDENUP_MANIFEST_URI", "https://127.0.0.1:1/nope.json")
         .output()
         .expect("failed to run miden");
 
@@ -200,12 +190,8 @@ fn integration_an_operation_needing_upstream_falls_back_to_the_cached_manifest()
     let fixture = common::harness::OfflineFixture::create(env.tmp_dir.path(), "0.15.0");
 
     let midenup = |manifest_uri: &str, args: &[&str]| {
-        Command::new(env!("CARGO_BIN_EXE_midenup"))
+        midenup_command(env!("CARGO_BIN_EXE_midenup"), &env, manifest_uri)
             .args(args)
-            .current_dir(&env.present_working_dir)
-            .env("MIDENUP_HOME", &env.midenup_home)
-            .env("CARGO_HOME", &env.cargo_home)
-            .env("MIDENUP_MANIFEST_URI", manifest_uri)
             .output()
             .expect("failed to run midenup")
     };

--- a/tests/migrate_v1.rs
+++ b/tests/migrate_v1.rs
@@ -5,7 +5,7 @@
 //! fetched, so an unreachable upstream cannot strand a user on an unreadable local document. An
 //! in-process test that builds its own `Config` has already done the fetch.
 
-use std::{path::Path, process::Command};
+use std::path::Path;
 
 use midenup::{
     migrate_v1::v1_manifest_path,
@@ -136,12 +136,8 @@ fn integration_recovery_a_failure_before_the_migration_commit_preserves_the_v1_d
     let path = v1_manifest_path(&env.midenup_home);
     let before = std::fs::read(&path).unwrap();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_midenup"))
+    let output = midenup_command(env!("CARGO_BIN_EXE_midenup"), &env, UNREACHABLE_UPSTREAM)
         .arg("list")
-        .current_dir(&env.present_working_dir)
-        .env("MIDENUP_HOME", &env.midenup_home)
-        .env("CARGO_HOME", &env.cargo_home)
-        .env("MIDENUP_MANIFEST_URI", UNREACHABLE_UPSTREAM)
         .env(midenup::fault::FAULT_POINT_ENV, "pre-migration-commit")
         .output()
         .expect("failed to run midenup");
@@ -220,12 +216,8 @@ fn integration_a_migrated_installation_is_reinstalled_on_first_use() {
     );
 
     // Dispatch triggers the install, exactly as it would for a toolchain that was never installed.
-    let output = Command::new(env!("CARGO_BIN_EXE_midenup"))
+    let output = midenup_command(env!("CARGO_BIN_EXE_midenup"), &env, &manifest)
         .args(["install", "0.15.0", "--profile", "minimal"])
-        .current_dir(&env.present_working_dir)
-        .env("MIDENUP_HOME", &env.midenup_home)
-        .env("CARGO_HOME", &env.cargo_home)
-        .env("MIDENUP_MANIFEST_URI", &manifest)
         .output()
         .expect("failed to run midenup");
     assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
@@ -256,7 +248,8 @@ fn integration_migrated_roots_missing_upstream_are_dropped_once_with_a_warning()
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let reported = String::from_utf8_lossy(&output.stdout);
+    // Diagnostics go to stderr; stdout carries results.
+    let reported = String::from_utf8_lossy(&output.stderr);
     assert!(reported.contains("goneaway"), "the dropped root must be named: {reported}");
 
     let installation = &state_of(&env.midenup_home).installations[0];

--- a/tests/operations.rs
+++ b/tests/operations.rs
@@ -600,12 +600,8 @@ fn integration_partial_status_is_derived_from_upstream_not_stored() {
         fixture.manifest("manifest.json", &[("vm", &["minimal"], &[]), ("extra", &[], &[])]);
 
     let midenup = |manifest_uri: &str, args: &[&str]| {
-        std::process::Command::new(env!("CARGO_BIN_EXE_midenup"))
+        midenup_command(env!("CARGO_BIN_EXE_midenup"), &env, manifest_uri)
             .args(args)
-            .current_dir(&env.present_working_dir)
-            .env("MIDENUP_HOME", &env.midenup_home)
-            .env("CARGO_HOME", &env.cargo_home)
-            .env("MIDENUP_MANIFEST_URI", manifest_uri)
             .output()
             .expect("failed to run midenup")
     };

--- a/tests/reporting.rs
+++ b/tests/reporting.rs
@@ -57,8 +57,6 @@ fn integration_reporting_an_install_names_its_channel_up_front() {
     let (stdout, stderr) = streams(&output);
     assert!(output.status.success(), "install must succeed: {stderr}");
 
-    // The sync covers the whole manifest, so it names no channel; `stable` is a synonym for the
-    // mainnet network, which resolves to a version, and the install line states both halves.
     assert!(
         stderr.contains("syncing channel updates from upstream"),
         "the sync must be announced: {stderr}"

--- a/tests/reporting.rs
+++ b/tests/reporting.rs
@@ -1,0 +1,227 @@
+//! What `midenup` says while it works: which stream it lands on, and how the level is chosen.
+//!
+//! Every assertion here is on a real process's streams, because the split between them is the
+//! contract: stdout is what the command was asked for, stderr is how it went.
+
+use std::process::Output;
+
+mod common;
+
+use common::*;
+
+/// Runs the real binary against `env`.
+fn run(env: &TestEnvironment, manifest_uri: &str, args: &[&str]) -> Output {
+    midenup_command(env!("CARGO_BIN_EXE_midenup"), env, manifest_uri)
+        .args(args)
+        .output()
+        .expect("failed to run midenup")
+}
+
+fn streams(output: &Output) -> (String, String) {
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// The default level announces each component, and does it on stderr.
+#[test]
+fn integration_reporting_default_announces_components_on_stderr() {
+    let _guard = common::harness::mutating_test_guard();
+    let test_env = environment_setup("integration_reporting_default");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
+
+    let output = run(&test_env, &fixture.manifest_uri, &["install", "stable"]);
+    let (stdout, stderr) = streams(&output);
+    assert!(output.status.success(), "install must succeed: {stderr}");
+
+    assert!(stderr.contains("component 'vm'"), "each component must be announced: {stderr}");
+    assert!(
+        stderr.contains("installed channel '0.15.0'"),
+        "and the channel at the end: {stderr}"
+    );
+    assert!(
+        !stdout.contains("component '"),
+        "announcements are progress, and must not reach stdout: {stdout}"
+    );
+}
+
+/// An install says what it is installing, and how fresh the data behind it is, before it starts.
+#[test]
+fn integration_reporting_an_install_names_its_channel_up_front() {
+    let _guard = common::harness::mutating_test_guard();
+    let test_env = environment_setup("integration_reporting_header");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
+
+    let output = run(&test_env, &fixture.manifest_uri, &["install", "stable"]);
+    let (stdout, stderr) = streams(&output);
+    assert!(output.status.success(), "install must succeed: {stderr}");
+
+    // The sync covers the whole manifest, so it names no channel; `stable` is a synonym for the
+    // mainnet network, which resolves to a version, and the install line states both halves.
+    assert!(
+        stderr.contains("syncing channel updates from upstream"),
+        "the sync must be announced: {stderr}"
+    );
+    assert!(
+        stderr.contains("upstream last updated on"),
+        "and how fresh the manifest behind it is: {stderr}"
+    );
+    assert!(
+        stderr.contains("installing mainnet (0.15.0)"),
+        "the install line must name the network and what it resolved to: {stderr}"
+    );
+    assert!(!stdout.contains("syncing"), "the header is progress, not a result: {stdout}");
+
+    // Ordering is the point of a header: sync, then what resolved, then the work.
+    let sync = stderr.find("syncing channel updates").expect("the sync must be announced");
+    let installing = stderr.find("installing mainnet").expect("the install line must be present");
+    let first_component = stderr.find("component '").expect("components must be announced");
+    assert!(sync < installing, "the sync precedes the resolution it enables: {stderr}");
+    assert!(installing < first_component, "and the header precedes the work: {stderr}");
+}
+
+/// A version requested directly is named once, not as `0.15.0 (0.15.0)`.
+#[test]
+fn integration_reporting_a_version_install_is_not_named_twice() {
+    let _guard = common::harness::mutating_test_guard();
+    let test_env = environment_setup("integration_reporting_header_version");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
+
+    let output = run(&test_env, &fixture.manifest_uri, &["install", "0.15.0"]);
+    let (_, stderr) = streams(&output);
+    assert!(output.status.success(), "install must succeed: {stderr}");
+    assert!(
+        stderr.contains("installing 0.15.0"),
+        "the install line must name the channel: {stderr}"
+    );
+    assert!(
+        !stderr.contains("0.15.0 (0.15.0)"),
+        "and must not restate it as its own resolution: {stderr}"
+    );
+}
+
+/// A component built from source says so, and inline at its own position -- unlike a package
+/// extraction, which is batched to the end of the install.
+#[test]
+fn integration_reporting_a_source_build_is_announced_in_place() {
+    let _guard = common::harness::mutating_test_guard();
+    let test_env = environment_setup("integration_reporting_build");
+    let fixture = common::harness::OfflineFixture::new(test_env.tmp_dir.path())
+        .with_channel("0.15.0")
+        .with_cargo_component("prover")
+        .build();
+
+    let output = run(&test_env, &fixture.manifest_uri, &["install", "stable"]);
+    let (stdout, stderr) = streams(&output);
+    assert!(output.status.success(), "install must succeed: {stderr}");
+
+    assert!(
+        stderr.contains("building component 'prover' from source"),
+        "a build must be announced as a build: {stderr}"
+    );
+    assert!(
+        !stdout.contains("building component"),
+        "which is progress, and does not belong on stdout: {stdout}"
+    );
+
+    // The fixture's artifacts are `file://`, so its prebuilt components are copied rather than
+    // downloaded. Either way they are the cheap steps the build sits among.
+    let build = stderr.find("building component").expect("the build must be announced");
+    let last_transfer = stderr
+        .rfind("copying component")
+        .expect("the prebuilt components must be announced");
+    assert!(
+        build < last_transfer,
+        "an inline build is not the last thing to happen: {stderr}"
+    );
+}
+
+/// The work ahead is described before it starts, and each announcement says where in it we are.
+#[test]
+fn integration_reporting_states_the_work_ahead_and_counts_through_it() {
+    let _guard = common::harness::mutating_test_guard();
+    let test_env = environment_setup("integration_reporting_progress");
+    let fixture = common::harness::OfflineFixture::new(test_env.tmp_dir.path())
+        .with_channel("0.15.0")
+        .with_cargo_component("prover")
+        .build();
+
+    let output = run(&test_env, &fixture.manifest_uri, &["install", "stable"]);
+    let (_, stderr) = streams(&output);
+    assert!(output.status.success(), "install must succeed: {stderr}");
+
+    assert!(
+        stderr.contains("3 steps: 2 copies, 1 source build"),
+        "the summary must break the work down by kind: {stderr}"
+    );
+
+    // The counter must reach its total.
+    for position in ["[1/3]", "[2/3]", "[3/3]"] {
+        assert!(
+            stderr.contains(position),
+            "every position must appear, missing {position}: {stderr}"
+        );
+    }
+
+    let summary = stderr.find("3 steps:").expect("the summary must be present");
+    let first = stderr.find("[1/3]").expect("the first step must be numbered");
+    assert!(summary < first, "the summary must come before the work: {stderr}");
+}
+
+/// `--quiet` suppresses the announcements without suppressing the command's result.
+#[test]
+fn integration_reporting_quiet_suppresses_announcements_but_not_results() {
+    let _guard = common::harness::mutating_test_guard();
+    let test_env = environment_setup("integration_reporting_quiet");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
+
+    let installed = run(&test_env, &fixture.manifest_uri, &["-q", "install", "stable"]);
+    let (_, stderr) = streams(&installed);
+    assert!(installed.status.success(), "install must succeed: {stderr}");
+    assert!(
+        !stderr.contains("component '"),
+        "--quiet must not announce components: {stderr}"
+    );
+    assert!(
+        !stderr.contains("installed channel"),
+        "nor the channel it finished installing: {stderr}"
+    );
+    assert!(!stderr.contains("syncing channel updates"), "nor the header: {stderr}");
+
+    // The result of a command is not progress, so quiet has no bearing on it.
+    let shown = run(&test_env, &fixture.manifest_uri, &["-q", "show", "active-toolchain"]);
+    let (stdout, stderr) = streams(&shown);
+    assert!(shown.status.success(), "show must succeed: {stderr}");
+    // The active channel is the network name here, which is what `show` is being asked for.
+    assert!(stdout.contains("mainnet"), "the result belongs on stdout regardless: {stdout}");
+}
+
+/// The debug tier traces the individual actions, which the levels below it never mention.
+#[test]
+fn integration_reporting_debug_traces_individual_actions() {
+    let _guard = common::harness::mutating_test_guard();
+    let test_env = environment_setup("integration_reporting_debug");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
+
+    let output = run(&test_env, &fixture.manifest_uri, &["-vv", "install", "stable"]);
+    let (stdout, stderr) = streams(&output);
+    assert!(output.status.success(), "install must succeed: {stderr}");
+    assert!(stderr.contains("debug:"), "the debug tier must trace: {stderr}");
+    assert!(!stdout.contains("debug:"), "tracing is not a result: {stdout}");
+}
+
+/// Asking to be told more and less at once is a mistake worth reporting, not a precedence puzzle.
+#[test]
+fn integration_reporting_quiet_and_verbose_conflict() {
+    let test_env = environment_setup("integration_reporting_conflict");
+    let fixture = common::harness::OfflineFixture::create(test_env.tmp_dir.path(), "0.15.0");
+
+    let output = run(&test_env, &fixture.manifest_uri, &["-q", "-v", "list"]);
+    let (_, stderr) = streams(&output);
+    assert!(!output.status.success(), "the combination must be rejected");
+    assert!(
+        stderr.contains("cannot be used with"),
+        "and the rejection must name the conflict: {stderr}"
+    );
+}


### PR DESCRIPTION
Closes https://github.com/0xMiden/midenup/issues/224.

This PR adds prints that show the progress during midenup operations. There are 4 levels of verbosity:
- `-q`: warnings and errors only. No progress, no announcements.
- default: on installations shows one line per component as it is installed, plus a live transfer display on a terminal.
- `-v`: The above, and the output of spawned programs (e.g. cargo) is no longer suppressed.
- `-vv`: The above, and every action `midenup` takes is traced.

<details>
<summary>Example default installation</summary>

<img width="1200" height="700" alt="midenup-install-0 16" src="https://github.com/user-attachments/assets/e9b00909-5364-4650-8050-e42a2cef321e" />
</details>

<details>
<summary>Example verbose (`-v`) installation</summary>
<img width="987" height="700" alt="midenup-install-0 16-build-verbose" src="https://github.com/user-attachments/assets/b8a0681f-e527-45e7-bb7b-fdc912e3d90f" />

</details>

<details>
<summary>Example debug (`-vv`) installation</summary>
<img width="987" height="700" alt="midenup-install-0 15-debug" src="https://github.com/user-attachments/assets/6fbf8a42-8bb6-42f1-af79-b06f23f53ded" />

</details>

