### PR TITLE
fix: partial install detection

### DIFF
--- a/docs/src/design/spec.md
+++ b/docs/src/design/spec.md
@@ -558,7 +558,7 @@ the superset is a warning, and the component in the active view wins.
 
 ### 8.6 Partial status is derived
 
-Local state does not record a "partial" flag. When the upstream manifest is available, an installation is displayed as partial if its installed component set is a proper subset of the channel's complete set. When upstream is unavailable, partial status is not displayed.
+Local state does not record a "partial" flag. When the upstream manifest is available, an installation is displayed as partial if upstream resolves its recorded intent to components it does not hold — that is, the channel has grown within what the user asked for, not merely grown at all. An intent upstream can no longer resolve makes no claim, and when upstream is unavailable, partial status is not displayed.
 
 Components with no physical output (`command` with zero artifacts) count as installed for membership purposes and are exempt from physical verification (§9.6).
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -11,11 +11,11 @@ pub fn list(config: &Config, state: &LocalState) -> anyhow::Result<()> {
             let channel_name = &channel.name;
 
             // Partial status is *derived*, never recorded (spec section 8.6): an installation is
-            // partial exactly when it holds fewer components than the channel offers. A stored
-            // flag would be a second answer to a question the component set already answers, and
-            // the two would drift.
+            // partial exactly when upstream resolves its recorded intent to components it does
+            // not hold. A stored flag would be a second answer to a question the component set
+            // already answers, and the two would drift.
             let installed_indicator = match state.get(&channel.name) {
-                Some(installation) if installation.as_channel().is_partially_installed(channel) => {
+                Some(installation) if installation.is_partially_installed(channel) => {
                     format!(" {}", "(partially installed)".yellow())
                 },
                 Some(_) => format!(" {}", "(installed)".green()),

--- a/src/commands/show.rs
+++ b/src/commands/show.rs
@@ -117,11 +117,7 @@ impl ShowCommand {
 
                         if let Some(manifest) = upstream {
                             match manifest.get_channel_by_name(name) {
-                                Some(channel)
-                                    if installation
-                                        .as_channel()
-                                        .is_partially_installed(channel) =>
-                                {
+                                Some(channel) if installation.is_partially_installed(channel) => {
                                     line.push_str(&format!(
                                         " {}",
                                         "(partially installed)".yellow()

--- a/src/manifest/v3/channel.rs
+++ b/src/manifest/v3/channel.rs
@@ -64,14 +64,6 @@ impl Channel {
         self.components.iter_mut().find(|c| c.name == name)
     }
 
-    /// Whether this channel holds fewer components than the `upstream` one it is compared against.
-    ///
-    /// Derived, never recorded (spec section 8.6): a stored "partial" flag would be a second answer
-    /// to a question the component set already answers, and two answers can disagree.
-    pub fn is_partially_installed(&self, upstream: &Channel) -> bool {
-        self.components.len() < upstream.components.len()
-    }
-
     pub fn get_channel_dir(&self, config: &Config) -> PathBuf {
         let installed_toolchains_dir = config.midenup_home.join("toolchains");
         installed_toolchains_dir.join(format!("{}", self.name))

--- a/src/state/installation.rs
+++ b/src/state/installation.rs
@@ -120,4 +120,17 @@ impl Installation {
     pub fn as_channel(&self) -> crate::manifest::Channel {
         crate::manifest::Channel::new(self.channel.clone(), self.components.clone())
     }
+
+    /// Whether `upstream` resolves this record's intent to components it does not hold.
+    ///
+    /// Derived, never recorded (spec section 8.6). An intent upstream can no longer resolve makes
+    /// no claim: the installation holds everything it was asked for.
+    pub fn is_partially_installed(&self, upstream: &crate::manifest::Channel) -> bool {
+        let Ok(expected) = crate::resolve::resolve(upstream, &self.intent) else {
+            return false;
+        };
+        let installed: std::collections::BTreeSet<&str> =
+            self.components.iter().map(|c| c.name.as_ref()).collect();
+        expected.iter().any(|component| !installed.contains(component.name.as_ref()))
+    }
 }

--- a/tests/operations.rs
+++ b/tests/operations.rs
@@ -587,9 +587,9 @@ fn integration_an_alias_conflict_inside_the_active_view_is_an_error() {
     );
 }
 
-/// Spec section 8.6: local state carries no partial flag. The display derives it by comparing what
-/// is installed against the complete upstream channel -- and when upstream is unavailable, simply
-/// does not show it rather than guessing.
+/// Spec section 8.6: local state carries no partial flag. The display derives it by resolving the
+/// recorded intent against upstream -- and when upstream is unavailable, simply does not show it
+/// rather than guessing.
 #[test]
 fn integration_partial_status_is_derived_from_upstream_not_stored() {
     let _guard = common::harness::mutating_test_guard();
@@ -612,7 +612,18 @@ fn integration_partial_status_is_derived_from_upstream_not_stored() {
     let raw = std::fs::read_to_string(midenup::paths::state_path(&env.midenup_home)).unwrap();
     assert!(!raw.contains("partial"), "state must not persist a partial flag: {raw}");
 
-    let shown = midenup(&manifest, &["show", "list"]);
+    // `extra` belongs to no profile, so a minimal install that never asked for it is complete.
+    let complete = midenup(&manifest, &["show", "list"]);
+    assert!(
+        !String::from_utf8_lossy(&complete.stdout).contains("partially installed"),
+        "holding everything the intent resolves to is not partial: {}",
+        String::from_utf8_lossy(&complete.stdout)
+    );
+
+    // The minimal profile grows upstream, so the same intent now resolves to more than is held.
+    let grown =
+        fixture.manifest("grown.json", &[("vm", &["minimal"], &[]), ("extra", &["minimal"], &[])]);
+    let shown = midenup(&grown, &["show", "list"]);
     assert!(
         String::from_utf8_lossy(&shown.stdout).contains("partially installed"),
         "with upstream available it must be derived and shown: {}",


### PR DESCRIPTION
Display fixes for `midenup show list` command:
- `(partially installed)` no longer gets shown for every default install. The marker was derived by comparing with the channel's complete component set, which minimal installs never match. It is now derived by resolving the recorded install intent against upstream. It would show if a channel added a component after the user installed it.
- Network drift is reported per network, under the list. Before, the message was appended to the installed channel entry which made it confusing.